### PR TITLE
gha: set 'Reporting date' to today on tracked project field changes

### DIFF
--- a/.github/workflows/update-reporting-date-testing.md
+++ b/.github/workflows/update-reporting-date-testing.md
@@ -1,0 +1,37 @@
+# update-reporting-date workflow — Testing Guide
+
+## Prerequisites
+
+Make sure the setup from the guide is complete:
+- `GH_TOKEN` secret is set in the repository
+- The repository is linked to your project (`https://github.com/users/dgutierr/projects/1`)
+- The project has a **`Reporting date`** field of type **Date**
+
+---
+
+## Testing steps
+
+1. **Merge the PR** (or enable Actions on the branch if GitHub allows it)
+
+2. **Go to your project** → `https://github.com/users/dgutierr/projects/1`
+
+3. **Pick any issue/item** in the project and change one of the tracked fields:
+   - Status, Priority, Estimate, Remaining Work, or Time Spent
+
+4. **Check the workflow ran** → go to your repository → **Actions** tab → you should see a run of `Update Reporting Date on Project Item Changes`
+
+5. **Verify the result** → go back to the project item and confirm the `Reporting date` field was updated to today's date
+
+---
+
+## Negative test (optional)
+
+Change a field that is **not** in the tracked list (e.g. a custom text field or the title). The workflow should either not trigger or be skipped — you'll see it listed in Actions with a grey "skipped" status.
+
+---
+
+## Troubleshooting
+
+- **Workflow doesn't trigger at all** → the repository is likely not linked to the project, or the `projects_v2_item` event is not enabled
+- **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` scope
+- **`Reporting date` field not found** → the field name in the project doesn't exactly match `Reporting date` (case-sensitive) — check the field name in the project settings

--- a/.github/workflows/update-reporting-date.md
+++ b/.github/workflows/update-reporting-date.md
@@ -1,0 +1,38 @@
+# update-reporting-date workflow — Setup Guide
+
+## What it does
+
+Automatically sets the `Reporting date` field to today in the GitHub Project whenever any of the following fields are edited on a project item: **Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**.
+
+No action is taken for changes to other fields or for repository issue changes.
+
+---
+
+## Setup
+
+### 1. Create a Personal Access Token (PAT)
+
+1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
+2. Click **"Generate new token (classic)"**
+3. Give it a name (e.g. `secret-santa-project-automation`)
+4. Under **Scopes**, check **`project`** — this grants read/write access to GitHub Projects v2
+5. Click **"Generate token"** and **copy it immediately** (you won't see it again)
+
+> Why not use the default `GITHUB_TOKEN`? That token is automatically created per workflow run and only has access to the repository itself. GitHub Projects (v2) at the user level are outside the repository scope, so the default token can't read or update project fields.
+
+### 2. Store the token as a repository secret
+
+1. Go to your repository: **`secret-santa-application` → Settings → Secrets and variables → Actions**
+2. Click **"New repository secret"**
+3. Set:
+   - **Name**: `GH_TOKEN` (exactly as referenced in the workflow)
+   - **Secret**: paste the token you copied above
+4. Click **"Add secret"**
+
+### 3. Verify the project is linked to the repository
+
+Make sure the repository is added to your project (`https://github.com/users/dgutierr/projects/1`). The `projects_v2_item` event only fires for projects that the workflow's repository is associated with. You can check this in the project settings under **"Manage access"** or by simply adding the repo from the project's side panel.
+
+---
+
+Once all three steps are done, the workflow will trigger automatically whenever a tracked field is edited in the project.

--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -1,0 +1,77 @@
+name: Update Reporting Date on Project Item Changes
+
+on:
+  projects_v2_item:
+    types: [edited]
+
+# Requires a PAT with 'project' scope stored as secret GH_TOKEN.
+# The default GITHUB_TOKEN does not have write access to user-level projects.
+
+jobs:
+  update-reporting-date:
+    name: Set 'Reporting date' to today
+    runs-on: ubuntu-latest
+    # Only run when one of the tracked fields is changed
+    if: |
+      contains(
+        fromJSON('["Status", "Priority", "Estimate", "Remaining Work", "Time Spent"]'),
+        github.event.changes.field_value.field_name
+      )
+    steps:
+      - name: Set 'Reporting date' field to today
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PROJECT_ID: ${{ github.event.projects_v2_item.project_node_id }}
+          ITEM_ID: ${{ github.event.projects_v2_item.node_id }}
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+
+          echo "Field '${CHANGED_FIELD}' changed — updating 'Reporting date' to $TODAY"
+
+          # Resolve the 'Reporting date' field ID from the project
+          REPORTING_DATE_FIELD_ID=$(gh api graphql -f query='
+            query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  fields(first: 30) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" \
+            --jq '.data.node.fields.nodes[] | select(.name == "Reporting date") | .id')
+
+          if [ -z "$REPORTING_DATE_FIELD_ID" ]; then
+            echo "Error: 'Reporting date' field not found in project $PROJECT_ID."
+            exit 1
+          fi
+
+          echo "Resolved 'Reporting date' field ID: $REPORTING_DATE_FIELD_ID"
+
+          # Update the 'Reporting date' field value to today
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { date: $date }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }
+          ' \
+            -f projectId="$PROJECT_ID" \
+            -f itemId="$ITEM_ID" \
+            -f fieldId="$REPORTING_DATE_FIELD_ID" \
+            -f date="$TODAY"
+
+          echo "Successfully set 'Reporting date' to $TODAY for item $ITEM_ID"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow triggered by `projects_v2_item` edited events
- Automatically sets the `Reporting date` project field to today when any of these fields change: **Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**
- No action is taken for changes to other fields or for repository issue changes

## Notes

- Requires a PAT with `project` scope stored as the `GH_TOKEN` repository secret (the default `GITHUB_TOKEN` lacks write access to user-level projects)
- The `Reporting date` field ID is resolved dynamically via GraphQL, so no hardcoded IDs are needed

Closes #1