### PR TITLE
docs: update setup and testing guides for org-level project

### DIFF
--- a/.github/workflows/update-reporting-date-testing.md
+++ b/.github/workflows/update-reporting-date-testing.md
@@ -3,24 +3,22 @@
 ## Prerequisites
 
 Make sure the setup from the guide is complete:
-- `GH_TOKEN` secret is set in the repository
-- The repository is linked to your project (`https://github.com/users/dgutierr/projects/1`)
+- `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
+- The repository is linked to the organization project (`https://github.com/orgs/dgutierr-org/projects/1`)
 - The project has a **`Reporting date`** field of type **Date**
 
 ---
 
 ## Testing steps
 
-1. **Merge the PR** (or enable Actions on the branch if GitHub allows it)
+1. **Go to your project** → `https://github.com/orgs/dgutierr-org/projects/1`
 
-2. **Go to your project** → `https://github.com/users/dgutierr/projects/1`
-
-3. **Pick any issue/item** in the project and change one of the tracked fields:
+2. **Pick any issue/item** in the project and change one of the tracked fields:
    - Status, Priority, Estimate, Remaining Work, or Time Spent
 
-4. **Check the workflow ran** → go to your repository → **Actions** tab → you should see a run of `Update Reporting Date on Project Item Changes`
+3. **Check the workflow ran** → go to your repository → **Actions** tab → you should see a run of `Update Reporting Date on Project Item Changes`
 
-5. **Verify the result** → go back to the project item and confirm the `Reporting date` field was updated to today's date
+4. **Verify the result** → go back to the project item and confirm the `Reporting date` field was updated to today's date
 
 ---
 
@@ -32,6 +30,6 @@ Change a field that is **not** in the tracked list (e.g. a custom text field or 
 
 ## Troubleshooting
 
-- **Workflow doesn't trigger at all** → the repository is likely not linked to the project, or the `projects_v2_item` event is not enabled
-- **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` scope
+- **Workflow doesn't trigger at all** → the repository is likely not linked to the organization project, or the project is not owned by an organization (`projects_v2_item` only works for org-level projects)
+- **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` and `read:org` scopes
 - **`Reporting date` field not found** → the field name in the project doesn't exactly match `Reporting date` (case-sensitive) — check the field name in the project settings

--- a/.github/workflows/update-reporting-date.md
+++ b/.github/workflows/update-reporting-date.md
@@ -6,6 +6,8 @@ Automatically sets the `Reporting date` field to today in the GitHub Project whe
 
 No action is taken for changes to other fields or for repository issue changes.
 
+> **Note:** The `projects_v2_item` event that triggers this workflow is only available for **organization-level projects**. The project must be owned by a GitHub organization (not a personal account). This workflow is configured for `https://github.com/orgs/dgutierr-org/projects/1`.
+
 ---
 
 ## Setup
@@ -15,10 +17,12 @@ No action is taken for changes to other fields or for repository issue changes.
 1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
 2. Click **"Generate new token (classic)"**
 3. Give it a name (e.g. `secret-santa-project-automation`)
-4. Under **Scopes**, check **`project`** — this grants read/write access to GitHub Projects v2
+4. Under **Scopes**, check both:
+   - **`project`** — grants read/write access to GitHub Projects v2
+   - **`read:org`** — required to access organization-level project data
 5. Click **"Generate token"** and **copy it immediately** (you won't see it again)
 
-> Why not use the default `GITHUB_TOKEN`? That token is automatically created per workflow run and only has access to the repository itself. GitHub Projects (v2) at the user level are outside the repository scope, so the default token can't read or update project fields.
+> Why not use the default `GITHUB_TOKEN`? That token is automatically created per workflow run and is scoped to the repository only. It cannot read or write fields on organization-level GitHub Projects v2.
 
 ### 2. Store the token as a repository secret
 
@@ -29,9 +33,13 @@ No action is taken for changes to other fields or for repository issue changes.
    - **Secret**: paste the token you copied above
 4. Click **"Add secret"**
 
-### 3. Verify the project is linked to the repository
+### 3. Link the repository to the organization project
 
-Make sure the repository is added to your project (`https://github.com/users/dgutierr/projects/1`). The `projects_v2_item` event only fires for projects that the workflow's repository is associated with. You can check this in the project settings under **"Manage access"** or by simply adding the repo from the project's side panel.
+The `projects_v2_item` event only fires for projects that the repository is associated with. To link it:
+
+1. Go to **`https://github.com/orgs/dgutierr-org/projects/1`**
+2. Open the project **Settings → Manage access**
+3. Add the `secret-santa-application` repository, or add it from the issue/PR side panel inside the project
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates `update-reporting-date.md` and `update-reporting-date-testing.md` to reflect the migration from a personal project to the organization project `https://github.com/orgs/dgutierr-org/projects/1`
- Adds a note explaining that `projects_v2_item` only works for organization-level projects
- Adds `read:org` as a required PAT scope alongside `project`
- Updates the project URL references from `users/dgutierr` to `orgs/dgutierr-org`
- Removes the stale "Merge the PR" step from the testing guide
- Updates the troubleshooting entries to mention the org-level project requirement