### PR TITLE
gha: replace event trigger with scheduled hash-based approach for 'Reporting date'

### DIFF
--- a/.github/workflows/update-reporting-date-testing.md
+++ b/.github/workflows/update-reporting-date-testing.md
@@ -4,8 +4,7 @@
 
 Make sure the setup from the guide is complete:
 - `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
-- The repository is linked to the organization project (`https://github.com/orgs/dgutierr-org/projects/1`)
-- The project has a **`Reporting date`** field of type **Date**
+- The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting date`** (Date) and a **`Reporting Hash`** (Text) field
 
 ---
 
@@ -16,20 +15,33 @@ Make sure the setup from the guide is complete:
 2. **Pick any issue/item** in the project and change one of the tracked fields:
    - Status, Priority, Estimate, Remaining Work, or Time Spent
 
-3. **Check the workflow ran** → go to your repository → **Actions** tab → you should see a run of `Update Reporting Date on Project Item Changes`
+3. **Wait up to 2 minutes** for the scheduled workflow to trigger
 
-4. **Verify the result** → go back to the project item and confirm the `Reporting date` field was updated to today's date
+4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Update Reporting Date on Project Item Changes` and inspect the logs. You should see the item listed with a hash mismatch and an update confirmation.
+
+5. **Verify the result** → go back to the project item and confirm:
+   - `Reporting date` is set to today
+   - `Reporting Hash` has been updated to a new SHA-256 value
+
+---
+
+## Manual trigger (skip the 2-minute wait)
+
+1. Go to **Actions → Update Reporting Date on Project Item Changes → Run workflow**
+2. Click **"Run workflow"**
+3. The workflow runs immediately against the latest project state
 
 ---
 
 ## Negative test (optional)
 
-Change a field that is **not** in the tracked list (e.g. a custom text field or the title). The workflow should either not trigger or be skipped — you'll see it listed in Actions with a grey "skipped" status.
+Change a field that is **not** in the tracked list (e.g. title or assignee). After the next workflow run, the logs should show the item was processed but skipped with `Hashes match — no tracked field changed`.
 
 ---
 
 ## Troubleshooting
 
-- **Workflow doesn't trigger at all** → the repository is likely not linked to the organization project, or the project is not owned by an organization (`projects_v2_item` only works for org-level projects)
 - **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` and `read:org` scopes
-- **`Reporting date` field not found** → the field name in the project doesn't exactly match `Reporting date` (case-sensitive) — check the field name in the project settings
+- **`Reporting date` field not found** → the field name in the project doesn't exactly match `Reporting date` (case-sensitive)
+- **`Reporting Hash` field not found** → the field name in the project doesn't exactly match `Reporting Hash` (case-sensitive), or the field hasn't been created yet
+- **Item not processed** → the item's `updatedAt` timestamp fell outside the 3-minute lookback window; trigger the workflow manually to force a full check

--- a/.github/workflows/update-reporting-date.md
+++ b/.github/workflows/update-reporting-date.md
@@ -2,17 +2,24 @@
 
 ## What it does
 
-Automatically sets the `Reporting date` field to today in the GitHub Project whenever any of the following fields are edited on a project item: **Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**.
+Runs every 2 minutes and checks all project items updated in the last 3 minutes. For each recently updated item it computes a SHA-256 hash of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) and compares it against the value stored in the **`Reporting Hash`** field. If the hashes differ, one of the tracked fields has changed and **`Reporting date`** is set to today. The new hash is then saved back to **`Reporting Hash`** for the next comparison.
 
-No action is taken for changes to other fields or for repository issue changes.
-
-> **Note:** The `projects_v2_item` event that triggers this workflow is only available for **organization-level projects**. The project must be owned by a GitHub organization (not a personal account). This workflow is configured for `https://github.com/orgs/dgutierr-org/projects/1`.
+No action is taken when non-tracked fields change (e.g. title, assignee).
 
 ---
 
 ## Setup
 
-### 1. Create a Personal Access Token (PAT)
+### 1. Add the required fields to the project
+
+In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the following fields exist:
+
+| Field name       | Type   | Purpose                                      |
+|------------------|--------|----------------------------------------------|
+| `Reporting date` | Date   | Set to today when a tracked field changes    |
+| `Reporting Hash` | Text   | Stores the hash of the last known field state |
+
+### 2. Create a Personal Access Token (PAT)
 
 1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
 2. Click **"Generate new token (classic)"**
@@ -24,7 +31,7 @@ No action is taken for changes to other fields or for repository issue changes.
 
 > Why not use the default `GITHUB_TOKEN`? That token is automatically created per workflow run and is scoped to the repository only. It cannot read or write fields on organization-level GitHub Projects v2.
 
-### 2. Store the token as a repository secret
+### 3. Store the token as a repository secret
 
 1. Go to your repository: **`secret-santa-application` → Settings → Secrets and variables → Actions**
 2. Click **"New repository secret"**
@@ -33,14 +40,6 @@ No action is taken for changes to other fields or for repository issue changes.
    - **Secret**: paste the token you copied above
 4. Click **"Add secret"**
 
-### 3. Link the repository to the organization project
-
-The `projects_v2_item` event only fires for projects that the repository is associated with. To link it:
-
-1. Go to **`https://github.com/orgs/dgutierr-org/projects/1`**
-2. Open the project **Settings → Manage access**
-3. Add the `secret-santa-application` repository, or add it from the issue/PR side panel inside the project
-
 ---
 
-Once all three steps are done, the workflow will trigger automatically whenever a tracked field is edited in the project.
+Once all steps are done, the workflow will run automatically every 2 minutes and update `Reporting date` whenever a tracked field is changed.

--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -1,77 +1,185 @@
 name: Update Reporting Date on Project Item Changes
 
 on:
-  projects_v2_item:
-    types: [edited]
+  schedule:
+    - cron: '*/2 * * * *'
+  workflow_dispatch:
 
-# Requires a PAT with 'project' scope stored as secret GH_TOKEN.
-# The default GITHUB_TOKEN does not have write access to user-level projects.
+# Requires a PAT with 'project' and 'read:org' scopes stored as secret GH_TOKEN.
+# The default GITHUB_TOKEN does not have write access to organization-level projects.
 
 jobs:
   update-reporting-date:
-    name: Set 'Reporting date' to today
+    name: Check and update 'Reporting date'
     runs-on: ubuntu-latest
-    # Only run when one of the tracked fields is changed
-    if: |
-      contains(
-        fromJSON('["Status", "Priority", "Estimate", "Remaining Work", "Time Spent"]'),
-        github.event.changes.field_value.field_name
-      )
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      PROJECT_OWNER: dgutierr-org
+      PROJECT_NUMBER: 1
+      LOOKBACK_MINUTES: 3
     steps:
-      - name: Set 'Reporting date' field to today
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          PROJECT_ID: ${{ github.event.projects_v2_item.project_node_id }}
-          ITEM_ID: ${{ github.event.projects_v2_item.node_id }}
+      - name: Update 'Reporting date' for items with changed tracked fields
         run: |
+          set -e
+
           TODAY=$(date -u +%Y-%m-%d)
+          CUTOFF_EPOCH=$(date -u -d "${LOOKBACK_MINUTES} minutes ago" +%s)
 
-          echo "Field '${CHANGED_FIELD}' changed — updating 'Reporting date' to $TODAY"
+          # Extract a field value from a project item JSON blob by field name.
+          # Handles text, number, single-select and date field types.
+          get_field() {
+            local item_json="$1"
+            local field_name="$2"
+            echo "$item_json" | jq -r --arg n "$field_name" '
+              [ .fieldValues.nodes[] | select(.field.name == $n) ] |
+              if length == 0 then ""
+              else .[0] |
+                if .text != null then .text
+                elif .number != null then (.number | tostring)
+                elif .["name"] != null then .["name"]
+                elif .date != null then .date
+                else ""
+                end
+              end
+            '
+          }
 
-          # Resolve the 'Reporting date' field ID from the project
-          REPORTING_DATE_FIELD_ID=$(gh api graphql -f query='
-            query($projectId: ID!) {
-              node(id: $projectId) {
-                ... on ProjectV2 {
+          # Fetch all project items along with their field metadata and values
+          RESPONSE=$(gh api graphql -f query='
+            query($owner: String!, $number: Int!) {
+              organization(login: $owner) {
+                projectV2(number: $number) {
+                  id
                   fields(first: 30) {
                     nodes {
                       ... on ProjectV2Field {
                         id
                         name
                       }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                      }
+                    }
+                  }
+                  items(first: 100) {
+                    nodes {
+                      id
+                      updatedAt
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldTextValue {
+                            text
+                            field { ... on ProjectV2Field { name } }
+                          }
+                          ... on ProjectV2ItemFieldNumberValue {
+                            number
+                            field { ... on ProjectV2Field { name } }
+                          }
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2SingleSelectField { name } }
+                          }
+                          ... on ProjectV2ItemFieldDateValue {
+                            date
+                            field { ... on ProjectV2Field { name } }
+                          }
+                        }
+                      }
                     }
                   }
                 }
               }
             }
-          ' -f projectId="$PROJECT_ID" \
-            --jq '.data.node.fields.nodes[] | select(.name == "Reporting date") | .id')
+          ' -f owner="$PROJECT_OWNER" -F number=$PROJECT_NUMBER)
+
+          PROJECT_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.id')
+          REPORTING_DATE_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting date") | .id')
+          REPORTING_HASH_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Hash") | .id')
 
           if [ -z "$REPORTING_DATE_FIELD_ID" ]; then
-            echo "Error: 'Reporting date' field not found in project $PROJECT_ID."
+            echo "Error: 'Reporting date' field not found in project."
+            exit 1
+          fi
+          if [ -z "$REPORTING_HASH_FIELD_ID" ]; then
+            echo "Error: 'Reporting Hash' field not found in project."
             exit 1
           fi
 
-          echo "Resolved 'Reporting date' field ID: $REPORTING_DATE_FIELD_ID"
+          echo "Project ID             : $PROJECT_ID"
+          echo "Reporting date field ID: $REPORTING_DATE_FIELD_ID"
+          echo "Reporting Hash field ID: $REPORTING_HASH_FIELD_ID"
+          echo "Processing items updated since: $(date -u -d "${LOOKBACK_MINUTES} minutes ago")"
 
-          # Update the 'Reporting date' field value to today
-          gh api graphql -f query='
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $projectId
-                itemId: $itemId
-                fieldId: $fieldId
-                value: { date: $date }
-              }) {
-                projectV2Item {
-                  id
-                }
+          UPDATED_COUNT=0
+          SKIPPED_COUNT=0
+
+          while IFS= read -r item; do
+            ITEM_ID=$(echo "$item" | jq -r '.id')
+            UPDATED_AT=$(echo "$item" | jq -r '.updatedAt')
+            UPDATED_EPOCH=$(date -u -d "$UPDATED_AT" +%s)
+
+            # Skip items outside the lookback window
+            if [ "$UPDATED_EPOCH" -lt "$CUTOFF_EPOCH" ]; then
+              continue
+            fi
+
+            echo ""
+            echo "Item $ITEM_ID (updatedAt: $UPDATED_AT)"
+
+            STATUS=$(get_field "$item" "Status")
+            PRIORITY=$(get_field "$item" "Priority")
+            ESTIMATE=$(get_field "$item" "Estimate")
+            REMAINING_WORK=$(get_field "$item" "Remaining Work")
+            TIME_SPENT=$(get_field "$item" "Time Spent")
+            STORED_HASH=$(get_field "$item" "Reporting Hash")
+
+            # Compute hash of the tracked fields in a fixed order
+            HASH_INPUT="${STATUS}|${PRIORITY}|${ESTIMATE}|${REMAINING_WORK}|${TIME_SPENT}"
+            CURRENT_HASH=$(echo -n "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
+
+            echo "  Tracked fields : $HASH_INPUT"
+            echo "  Current hash   : $CURRENT_HASH"
+            echo "  Stored hash    : $STORED_HASH"
+
+            if [ "$CURRENT_HASH" = "$STORED_HASH" ]; then
+              echo "  → Hashes match — no tracked field changed. Skipping."
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+              continue
+            fi
+
+            echo "  → Hash mismatch — updating 'Reporting date' to $TODAY and 'Reporting Hash'."
+
+            # Update 'Reporting date' to today
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { date: $date }
+                }) { projectV2Item { id } }
               }
-            }
-          ' \
-            -f projectId="$PROJECT_ID" \
-            -f itemId="$ITEM_ID" \
-            -f fieldId="$REPORTING_DATE_FIELD_ID" \
-            -f date="$TODAY"
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$REPORTING_DATE_FIELD_ID" -f date="$TODAY"
 
-          echo "Successfully set 'Reporting date' to $TODAY for item $ITEM_ID"
+            # Update 'Reporting Hash' to the current hash
+            gh api graphql -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { text: $text }
+                }) { projectV2Item { id } }
+              }
+            ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+              -f fieldId="$REPORTING_HASH_FIELD_ID" -f text="$CURRENT_HASH"
+
+            echo "  → Done."
+            UPDATED_COUNT=$((UPDATED_COUNT + 1))
+
+          done < <(echo "$RESPONSE" | jq -c '.data.organization.projectV2.items.nodes[]')
+
+          echo ""
+          echo "Summary: $UPDATED_COUNT item(s) updated, $SKIPPED_COUNT item(s) skipped."


### PR DESCRIPTION
## Summary

Replaces the broken `projects_v2_item` event trigger (unavailable on the free GitHub plan) with a scheduled cron approach using a hash-based change detection strategy.

- Workflow runs every 2 minutes (configurable via `LOOKBACK_MINUTES` and cron expression)
- For each recently updated project item, computes a SHA-256 hash of the 5 tracked fields: **Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**
- Compares the hash against the value stored in the new **`Reporting Hash`** project field
- If hashes differ → a tracked field changed → sets `Reporting date` to today and saves the new hash
- If hashes match → no tracked field changed → skips the item
- `workflow_dispatch` added for manual triggering during testing
- Updated setup and testing documentation accordingly

## Required project changes

Before merging, add a **`Reporting Hash`** field of type **Text** to `https://github.com/orgs/dgutierr-org/projects/1`.