### PR TITLE
fix: rename 'Reporting date' to 'Reporting Date' and fix cron to */5

### DIFF
--- a/.github/workflows/update-reporting-date-testing.md
+++ b/.github/workflows/update-reporting-date-testing.md
@@ -4,7 +4,7 @@
 
 Make sure the setup from the guide is complete:
 - `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
-- The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting date`** (Date) and a **`Reporting Hash`** (Text) field
+- The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting Date`** (Date) and a **`Reporting Hash`** (Text) field
 
 ---
 
@@ -15,12 +15,12 @@ Make sure the setup from the guide is complete:
 2. **Pick any issue/item** in the project and change one of the tracked fields:
    - Status, Priority, Estimate, Remaining Work, or Time Spent
 
-3. **Wait up to 2 minutes** for the scheduled workflow to trigger
+3. **Wait up to 5 minutes** for the scheduled workflow to trigger
 
 4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Update Reporting Date on Project Item Changes` and inspect the logs. You should see the item listed with a hash mismatch and an update confirmation.
 
 5. **Verify the result** → go back to the project item and confirm:
-   - `Reporting date` is set to today
+   - `Reporting Date` is set to today
    - `Reporting Hash` has been updated to a new SHA-256 value
 
 ---
@@ -42,6 +42,6 @@ Change a field that is **not** in the tracked list (e.g. title or assignee). Aft
 ## Troubleshooting
 
 - **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` and `read:org` scopes
-- **`Reporting date` field not found** → the field name in the project doesn't exactly match `Reporting date` (case-sensitive)
+- **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive)
 - **`Reporting Hash` field not found** → the field name in the project doesn't exactly match `Reporting Hash` (case-sensitive), or the field hasn't been created yet
-- **Item not processed** → the item's `updatedAt` timestamp fell outside the 3-minute lookback window; trigger the workflow manually to force a full check
+- **Item not processed** → the item's `updatedAt` timestamp fell outside the 6-minute lookback window; trigger the workflow manually to force a full check

--- a/.github/workflows/update-reporting-date.md
+++ b/.github/workflows/update-reporting-date.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-Runs every 2 minutes and checks all project items updated in the last 3 minutes. For each recently updated item it computes a SHA-256 hash of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) and compares it against the value stored in the **`Reporting Hash`** field. If the hashes differ, one of the tracked fields has changed and **`Reporting date`** is set to today. The new hash is then saved back to **`Reporting Hash`** for the next comparison.
+Runs every 5 minutes and checks all project items updated in the last 6 minutes. For each recently updated item it computes a SHA-256 hash of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) and compares it against the value stored in the **`Reporting Hash`** field. If the hashes differ, one of the tracked fields has changed and **`Reporting Date`** is set to today. The new hash is then saved back to **`Reporting Hash`** for the next comparison.
 
 No action is taken when non-tracked fields change (e.g. title, assignee).
 
@@ -16,7 +16,7 @@ In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the followin
 
 | Field name       | Type   | Purpose                                      |
 |------------------|--------|----------------------------------------------|
-| `Reporting date` | Date   | Set to today when a tracked field changes    |
+| `Reporting Date` | Date   | Set to today when a tracked field changes    |
 | `Reporting Hash` | Text   | Stores the hash of the last known field state |
 
 ### 2. Create a Personal Access Token (PAT)
@@ -42,4 +42,4 @@ In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the followin
 
 ---
 
-Once all steps are done, the workflow will run automatically every 2 minutes and update `Reporting date` whenever a tracked field is changed.
+Once all steps are done, the workflow will run automatically every 5 minutes and update `Reporting Date` whenever a tracked field is changed.

--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -2,7 +2,7 @@ name: Update Reporting Date on Project Item Changes
 
 on:
   schedule:
-    - cron: '*/2 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 # Requires a PAT with 'project' and 'read:org' scopes stored as secret GH_TOKEN.
@@ -10,15 +10,15 @@ on:
 
 jobs:
   update-reporting-date:
-    name: Check and update 'Reporting date'
+    name: Check and update 'Reporting Date'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       PROJECT_OWNER: dgutierr-org
       PROJECT_NUMBER: 1
-      LOOKBACK_MINUTES: 3
+      LOOKBACK_MINUTES: 6
     steps:
-      - name: Update 'Reporting date' for items with changed tracked fields
+      - name: Update 'Reporting Date' for items with changed tracked fields
         run: |
           set -e
 
@@ -94,11 +94,11 @@ jobs:
           ' -f owner="$PROJECT_OWNER" -F number=$PROJECT_NUMBER)
 
           PROJECT_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.id')
-          REPORTING_DATE_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting date") | .id')
+          REPORTING_DATE_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Date") | .id')
           REPORTING_HASH_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Hash") | .id')
 
           if [ -z "$REPORTING_DATE_FIELD_ID" ]; then
-            echo "Error: 'Reporting date' field not found in project."
+            echo "Error: 'Reporting Date' field not found in project."
             exit 1
           fi
           if [ -z "$REPORTING_HASH_FIELD_ID" ]; then
@@ -107,7 +107,7 @@ jobs:
           fi
 
           echo "Project ID             : $PROJECT_ID"
-          echo "Reporting date field ID: $REPORTING_DATE_FIELD_ID"
+          echo "Reporting Date field ID: $REPORTING_DATE_FIELD_ID"
           echo "Reporting Hash field ID: $REPORTING_HASH_FIELD_ID"
           echo "Processing items updated since: $(date -u -d "${LOOKBACK_MINUTES} minutes ago")"
 
@@ -148,9 +148,9 @@ jobs:
               continue
             fi
 
-            echo "  → Hash mismatch — updating 'Reporting date' to $TODAY and 'Reporting Hash'."
+            echo "  → Hash mismatch — updating 'Reporting Date' to $TODAY and 'Reporting Hash'."
 
-            # Update 'Reporting date' to today
+            # Update 'Reporting Date' to today
             gh api graphql -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
                 updateProjectV2ItemFieldValue(input: {


### PR DESCRIPTION
## Summary

- Renames all references from `Reporting date` → `Reporting Date` across the workflow and both documentation files
- Fixes the cron schedule from `*/2 * * * *` to `*/5 * * * *` — GitHub's minimum supported schedule interval is 5 minutes; the 2-minute value was silently ignored, causing the workflow to only run manually
- Bumps `LOOKBACK_MINUTES` from `3` to `6` to match the new 5-minute interval