### PR TITLE
docs: consolidate schedule config with inline comments in workflow

### DIFF
--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -1,8 +1,16 @@
 name: Update Reporting Date on Project Item Changes
 
+# ---------------------------------------------------------------------------
+# Schedule configuration
+# NOTE: GitHub Actions does not support variables in cron expressions.
+#       To change the polling interval, update BOTH values below manually:
+#         - cron: how often the workflow runs (minimum every 5 minutes)
+#         - LOOKBACK_MINUTES: must be slightly longer than the cron interval
+#           to avoid missing updates at the boundary (e.g. interval=5 → lookback=6)
+# ---------------------------------------------------------------------------
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/5 * * * *'   # <-- change polling interval here
   workflow_dispatch:
 
 # Requires a PAT with 'project' and 'read:org' scopes stored as secret GH_TOKEN.
@@ -16,7 +24,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       PROJECT_OWNER: dgutierr-org
       PROJECT_NUMBER: 1
-      LOOKBACK_MINUTES: 6
+      LOOKBACK_MINUTES: 6   # <-- change lookback window here
     steps:
       - name: Update 'Reporting Date' for items with changed tracked fields
         run: |


### PR DESCRIPTION
## Summary

Since GitHub Actions does not support variables in `schedule.cron` expressions, consolidates both timing-related settings (`cron` and `LOOKBACK_MINUTES`) at the top of the file with a clear comment block explaining the constraint and how to update them together.