### PR TITLE
feat: replace Reporting Hash with Reporting Log for change detection

### DIFF
--- a/.github/workflows/update-reporting-date-testing.md
+++ b/.github/workflows/update-reporting-date-testing.md
@@ -4,7 +4,7 @@
 
 Make sure the setup from the guide is complete:
 - `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
-- The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting Date`** (Date) and a **`Reporting Hash`** (Text) field
+- The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting Date`** (Date) and a **`Reporting Log`** (Text) field
 
 ---
 
@@ -17,15 +17,15 @@ Make sure the setup from the guide is complete:
 
 3. **Wait up to 5 minutes** for the scheduled workflow to trigger
 
-4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Update Reporting Date on Project Item Changes` and inspect the logs. You should see the item listed with a hash mismatch and an update confirmation.
+4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Update Reporting Date on Project Item Changes` and inspect the logs. You should see the item listed with a change detected and an update confirmation.
 
 5. **Verify the result** → go back to the project item and confirm:
    - `Reporting Date` is set to today
-   - `Reporting Hash` has been updated to a new SHA-256 value
+   - `Reporting Log` has a new entry in the format `YYYY-MM-DD | Status | Priority | Estimate | Remaining Work | Time Spent`
 
 ---
 
-## Manual trigger (skip the 2-minute wait)
+## Manual trigger (skip the 5-minute wait)
 
 1. Go to **Actions → Update Reporting Date on Project Item Changes → Run workflow**
 2. Click **"Run workflow"**
@@ -35,7 +35,7 @@ Make sure the setup from the guide is complete:
 
 ## Negative test (optional)
 
-Change a field that is **not** in the tracked list (e.g. title or assignee). After the next workflow run, the logs should show the item was processed but skipped with `Hashes match — no tracked field changed`.
+Change a field that is **not** in the tracked list (e.g. title or assignee). After the next workflow run, the logs should show the item was processed but skipped with `No change detected. Skipping.`
 
 ---
 
@@ -43,5 +43,5 @@ Change a field that is **not** in the tracked list (e.g. title or assignee). Aft
 
 - **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` and `read:org` scopes
 - **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive)
-- **`Reporting Hash` field not found** → the field name in the project doesn't exactly match `Reporting Hash` (case-sensitive), or the field hasn't been created yet
-- **Item not processed** → the item's `updatedAt` timestamp fell outside the 6-minute lookback window; trigger the workflow manually to force a full check
+- **`Reporting Log` field not found** → the field name in the project doesn't exactly match `Reporting Log` (case-sensitive), or the field hasn't been created yet
+- **Item not processed** → the item may not appear in the first 100 results; increase the `items(first: 100)` limit in the workflow if the project has more than 100 items

--- a/.github/workflows/update-reporting-date.md
+++ b/.github/workflows/update-reporting-date.md
@@ -2,7 +2,13 @@
 
 ## What it does
 
-Runs every 5 minutes and checks all project items updated in the last 6 minutes. For each recently updated item it computes a SHA-256 hash of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) and compares it against the value stored in the **`Reporting Hash`** field. If the hashes differ, one of the tracked fields has changed and **`Reporting Date`** is set to today. The new hash is then saved back to **`Reporting Hash`** for the next comparison.
+Runs every 5 minutes and checks **all** project items. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
+
+1. Sets **`Reporting Date`** to today
+2. Appends a new entry to **`Reporting Log`** in the format:
+   ```
+   YYYY-MM-DD | Status | Priority | Estimate | Remaining Work | Time Spent
+   ```
 
 No action is taken when non-tracked fields change (e.g. title, assignee).
 
@@ -14,10 +20,10 @@ No action is taken when non-tracked fields change (e.g. title, assignee).
 
 In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the following fields exist:
 
-| Field name       | Type   | Purpose                                      |
-|------------------|--------|----------------------------------------------|
-| `Reporting Date` | Date   | Set to today when a tracked field changes    |
-| `Reporting Hash` | Text   | Stores the hash of the last known field state |
+| Field name       | Type   | Purpose                                                        |
+|------------------|--------|----------------------------------------------------------------|
+| `Reporting Date` | Date   | Set to today when a tracked field changes                      |
+| `Reporting Log`  | Text   | Append-only log of tracked field values, one entry per change  |
 
 ### 2. Create a Personal Access Token (PAT)
 
@@ -42,4 +48,4 @@ In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the followin
 
 ---
 
-Once all steps are done, the workflow will run automatically every 5 minutes and update `Reporting Date` whenever a tracked field is changed.
+Once all steps are done, the workflow will run automatically every 5 minutes and update `Reporting Date` and `Reporting Log` whenever a tracked field is changed.

--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -3,10 +3,8 @@ name: Update Reporting Date on Project Item Changes
 # ---------------------------------------------------------------------------
 # Schedule configuration
 # NOTE: GitHub Actions does not support variables in cron expressions.
-#       To change the polling interval, update BOTH values below manually:
-#         - cron: how often the workflow runs (minimum every 5 minutes)
-#         - LOOKBACK_MINUTES: must be slightly longer than the cron interval
-#           to avoid missing updates at the boundary (e.g. interval=5 → lookback=6)
+#       To change the polling interval update the cron expression below
+#       (minimum every 5 minutes on the free GitHub plan).
 # ---------------------------------------------------------------------------
 on:
   schedule:
@@ -24,14 +22,12 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       PROJECT_OWNER: dgutierr-org
       PROJECT_NUMBER: 1
-      LOOKBACK_MINUTES: 6   # <-- change lookback window here
     steps:
-      - name: Update 'Reporting Date' for items with changed tracked fields
+      - name: Update 'Reporting Date' and 'Reporting Log' for changed items
         run: |
           set -e
 
           TODAY=$(date -u +%Y-%m-%d)
-          CUTOFF_EPOCH=$(date -u -d "${LOOKBACK_MINUTES} minutes ago" +%s)
 
           # Extract a field value from a project item JSON blob by field name.
           # Handles text, number, single-select and date field types.
@@ -73,7 +69,6 @@ jobs:
                   items(first: 100) {
                     nodes {
                       id
-                      updatedAt
                       fieldValues(first: 20) {
                         nodes {
                           ... on ProjectV2ItemFieldTextValue {
@@ -103,60 +98,73 @@ jobs:
 
           PROJECT_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.id')
           REPORTING_DATE_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Date") | .id')
-          REPORTING_HASH_FIELD_ID=$(echo "$RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Hash") | .id')
+          REPORTING_LOG_FIELD_ID=$(echo "$RESPONSE"  | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Log")  | .id')
 
           if [ -z "$REPORTING_DATE_FIELD_ID" ]; then
             echo "Error: 'Reporting Date' field not found in project."
             exit 1
           fi
-          if [ -z "$REPORTING_HASH_FIELD_ID" ]; then
-            echo "Error: 'Reporting Hash' field not found in project."
+          if [ -z "$REPORTING_LOG_FIELD_ID" ]; then
+            echo "Error: 'Reporting Log' field not found in project."
             exit 1
           fi
 
           echo "Project ID             : $PROJECT_ID"
           echo "Reporting Date field ID: $REPORTING_DATE_FIELD_ID"
-          echo "Reporting Hash field ID: $REPORTING_HASH_FIELD_ID"
-          echo "Processing items updated since: $(date -u -d "${LOOKBACK_MINUTES} minutes ago")"
+          echo "Reporting Log field ID : $REPORTING_LOG_FIELD_ID"
 
           UPDATED_COUNT=0
           SKIPPED_COUNT=0
 
           while IFS= read -r item; do
             ITEM_ID=$(echo "$item" | jq -r '.id')
-            UPDATED_AT=$(echo "$item" | jq -r '.updatedAt')
-            UPDATED_EPOCH=$(date -u -d "$UPDATED_AT" +%s)
+            echo ""
+            echo "Item $ITEM_ID"
 
-            # Skip items outside the lookback window
-            if [ "$UPDATED_EPOCH" -lt "$CUTOFF_EPOCH" ]; then
-              continue
+            STATUS=$(get_field        "$item" "Status")
+            PRIORITY=$(get_field      "$item" "Priority")
+            ESTIMATE=$(get_field      "$item" "Estimate")
+            REMAINING_WORK=$(get_field "$item" "Remaining Work")
+            TIME_SPENT=$(get_field    "$item" "Time Spent")
+            REPORTING_LOG=$(get_field "$item" "Reporting Log")
+
+            # Parse tracked field values from the last entry in the log
+            if [ -z "$REPORTING_LOG" ]; then
+              LAST_STATUS="" LAST_PRIORITY="" LAST_ESTIMATE=""
+              LAST_REMAINING_WORK="" LAST_TIME_SPENT=""
+            else
+              LAST_ENTRY=$(echo "$REPORTING_LOG" | grep -v '^[[:space:]]*$' | tail -1)
+              LAST_STATUS=$(echo        "$LAST_ENTRY" | cut -d'|' -f2 | xargs)
+              LAST_PRIORITY=$(echo      "$LAST_ENTRY" | cut -d'|' -f3 | xargs)
+              LAST_ESTIMATE=$(echo      "$LAST_ENTRY" | cut -d'|' -f4 | xargs)
+              LAST_REMAINING_WORK=$(echo "$LAST_ENTRY" | cut -d'|' -f5 | xargs)
+              LAST_TIME_SPENT=$(echo    "$LAST_ENTRY" | cut -d'|' -f6 | xargs)
             fi
 
-            echo ""
-            echo "Item $ITEM_ID (updatedAt: $UPDATED_AT)"
+            echo "  Current : $STATUS | $PRIORITY | $ESTIMATE | $REMAINING_WORK | $TIME_SPENT"
+            echo "  Last log: $LAST_STATUS | $LAST_PRIORITY | $LAST_ESTIMATE | $LAST_REMAINING_WORK | $LAST_TIME_SPENT"
 
-            STATUS=$(get_field "$item" "Status")
-            PRIORITY=$(get_field "$item" "Priority")
-            ESTIMATE=$(get_field "$item" "Estimate")
-            REMAINING_WORK=$(get_field "$item" "Remaining Work")
-            TIME_SPENT=$(get_field "$item" "Time Spent")
-            STORED_HASH=$(get_field "$item" "Reporting Hash")
-
-            # Compute hash of the tracked fields in a fixed order
-            HASH_INPUT="${STATUS}|${PRIORITY}|${ESTIMATE}|${REMAINING_WORK}|${TIME_SPENT}"
-            CURRENT_HASH=$(echo -n "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
-
-            echo "  Tracked fields : $HASH_INPUT"
-            echo "  Current hash   : $CURRENT_HASH"
-            echo "  Stored hash    : $STORED_HASH"
-
-            if [ "$CURRENT_HASH" = "$STORED_HASH" ]; then
-              echo "  → Hashes match — no tracked field changed. Skipping."
+            # Skip if nothing has changed
+            if [ "$STATUS"         = "$LAST_STATUS"         ] && \
+               [ "$PRIORITY"        = "$LAST_PRIORITY"        ] && \
+               [ "$ESTIMATE"        = "$LAST_ESTIMATE"        ] && \
+               [ "$REMAINING_WORK"  = "$LAST_REMAINING_WORK"  ] && \
+               [ "$TIME_SPENT"      = "$LAST_TIME_SPENT"      ]; then
+              echo "  → No change detected. Skipping."
               SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
               continue
             fi
 
-            echo "  → Hash mismatch — updating 'Reporting Date' to $TODAY and 'Reporting Hash'."
+            echo "  → Change detected. Updating 'Reporting Date' and appending to 'Reporting Log'."
+
+            # Build the new log entry and append it
+            NEW_ENTRY="${TODAY} | ${STATUS} | ${PRIORITY} | ${ESTIMATE} | ${REMAINING_WORK} | ${TIME_SPENT}"
+            if [ -z "$REPORTING_LOG" ]; then
+              NEW_LOG="$NEW_ENTRY"
+            else
+              NEW_LOG="${REPORTING_LOG}
+${NEW_ENTRY}"
+            fi
 
             # Update 'Reporting Date' to today
             gh api graphql -f query='
@@ -171,7 +179,7 @@ jobs:
             ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
               -f fieldId="$REPORTING_DATE_FIELD_ID" -f date="$TODAY"
 
-            # Update 'Reporting Hash' to the current hash
+            # Append new entry to 'Reporting Log'
             gh api graphql -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
                 updateProjectV2ItemFieldValue(input: {
@@ -182,7 +190,7 @@ jobs:
                 }) { projectV2Item { id } }
               }
             ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
-              -f fieldId="$REPORTING_HASH_FIELD_ID" -f text="$CURRENT_HASH"
+              -f fieldId="$REPORTING_LOG_FIELD_ID" -f text="$NEW_LOG"
 
             echo "  → Done."
             UPDATED_COUNT=$((UPDATED_COUNT + 1))


### PR DESCRIPTION
## Summary

- Replaces the `Reporting Hash` field with a `Reporting Log` text field that stores a human-readable audit trail of tracked field changes
- Each log entry is a newline-separated row in the format: `YYYY-MM-DD | Status | Priority | Estimate | Remaining Work | Time Spent`
- Change detection now compares current field values directly against the last entry in `Reporting Log` instead of comparing SHA-256 hashes
- Drops the `updatedAt` lookback filter — all items are checked on every run, making the automation resilient to missed schedule runs
- Removes `LOOKBACK_MINUTES` env var (no longer needed)
- Updated setup and testing documentation accordingly

## Required project changes

Before merging, add a **`Reporting Log`** field of type **Text** to `https://github.com/orgs/dgutierr-org/projects/1`. The `Reporting Hash` field can be removed.