### PR TITLE
fix: prepend Reporting Log entries so newest is first

### DIFF
--- a/.github/workflows/update-reporting-date-project-setup.md
+++ b/.github/workflows/update-reporting-date-project-setup.md
@@ -29,11 +29,11 @@ These fields are updated automatically and should not be edited manually.
 | Field name       | Type   | Purpose                                                       |
 |------------------|--------|---------------------------------------------------------------|
 | `Reporting Date` | Date   | Set to today whenever a tracked field changes                 |
-| `Reporting Log`  | Text   | Append-only log; one entry per change in the format below     |
+| `Reporting Log`  | Text   | Log of changes, newest entry first, one entry per change      |
 
 #### Reporting Log entry format
 
-Each entry is a newline-separated row:
+Each entry is a newline-separated row. Entries are ordered **newest first**, so the most recent change is always at the top:
 
 ```
 YYYY-MM-DD | Status | Priority | Estimate | Remaining Work | Time Spent
@@ -41,8 +41,8 @@ YYYY-MM-DD | Status | Priority | Estimate | Remaining Work | Time Spent
 
 Example:
 ```
-2026-03-01 | Backlog | High | 8 | 8 | 0
 2026-03-03 | In Progress | High | 8 | 5 | 3
+2026-03-01 | Backlog | High | 8 | 8 | 0
 ```
 
 ---

--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -128,12 +128,12 @@ jobs:
             TIME_SPENT=$(get_field    "$item" "Time Spent")
             REPORTING_LOG=$(get_field "$item" "Reporting Log")
 
-            # Parse tracked field values from the last entry in the log
+            # Parse tracked field values from the latest (first) entry in the log
             if [ -z "$REPORTING_LOG" ]; then
               LAST_STATUS="" LAST_PRIORITY="" LAST_ESTIMATE=""
               LAST_REMAINING_WORK="" LAST_TIME_SPENT=""
             else
-              LAST_ENTRY=$(echo "$REPORTING_LOG" | grep -v '^[[:space:]]*$' | tail -1)
+              LAST_ENTRY=$(echo "$REPORTING_LOG" | grep -v '^[[:space:]]*$' | head -1)
               LAST_STATUS=$(echo        "$LAST_ENTRY" | cut -d'|' -f2 | xargs)
               LAST_PRIORITY=$(echo      "$LAST_ENTRY" | cut -d'|' -f3 | xargs)
               LAST_ESTIMATE=$(echo      "$LAST_ENTRY" | cut -d'|' -f4 | xargs)
@@ -155,14 +155,14 @@ jobs:
               continue
             fi
 
-            echo "  → Change detected. Updating 'Reporting Date' and appending to 'Reporting Log'."
+            echo "  → Change detected. Updating 'Reporting Date' and prepending to 'Reporting Log'."
 
-            # Build the new log entry and append it
+            # Build the new log entry and prepend it (newest entry first)
             NEW_ENTRY="${TODAY} | ${STATUS} | ${PRIORITY} | ${ESTIMATE} | ${REMAINING_WORK} | ${TIME_SPENT}"
             if [ -z "$REPORTING_LOG" ]; then
               NEW_LOG="$NEW_ENTRY"
             else
-              NEW_LOG="${REPORTING_LOG}"$'\n'"${NEW_ENTRY}"
+              NEW_LOG="${NEW_ENTRY}"$'\n'"${REPORTING_LOG}"
             fi
 
             # Update 'Reporting Date' to today


### PR DESCRIPTION
## Summary

- New `Reporting Log` entries are now **prepended** instead of appended, so the log is ordered newest to oldest
- Comparison against the last known state now reads the **first line** (`head -1`) instead of the last (`tail -1`)
- Updated the project setup guide example to reflect the new order