### PR TITLE
fix: use ', ' as value separator and ' | ' as entry separator in Reporting Log

### DIFF
--- a/.github/workflows/update-reporting-date-project-setup.md
+++ b/.github/workflows/update-reporting-date-project-setup.md
@@ -33,15 +33,15 @@ These fields are updated automatically and should not be edited manually.
 
 #### Reporting Log entry format
 
-Entries are separated by `|`, ordered **newest first**. Each entry uses `,` to separate field values:
+Entries are separated by ` | `, ordered **newest first**. Field values within each entry are separated by `, `:
 
 ```
-DATE,Status,Priority,Estimate,Remaining Work,Time Spent
+DATE, Status, Priority, Estimate, Remaining Work, Time Spent
 ```
 
 Multiple entries example (newest → oldest, max 5):
 ```
-2026-03-03,In Progress,High,8,5,3|2026-03-01,Backlog,High,8,8,0
+2026-03-03, In Progress, High, 8, 5, 3 | 2026-03-01, Backlog, High, 8, 8, 0
 ```
 
 The oldest entry is automatically discarded when the log exceeds 5 entries.

--- a/.github/workflows/update-reporting-date-testing.md
+++ b/.github/workflows/update-reporting-date-testing.md
@@ -21,7 +21,7 @@ Make sure the setup from the guide is complete:
 
 5. **Verify the result** → go back to the project item and confirm:
    - `Reporting Date` is set to today
-   - `Reporting Log` has a new entry prepended in the format `YYYY-MM-DD,Status,Priority,Estimate,Remaining Work,Time Spent`, separated from older entries by `|`, with a maximum of 5 entries total
+   - `Reporting Log` has a new entry prepended in the format `YYYY-MM-DD, Status, Priority, Estimate, Remaining Work, Time Spent`, separated from older entries by ` | `, with a maximum of 5 entries total
 
 ---
 

--- a/.github/workflows/update-reporting-date.yml
+++ b/.github/workflows/update-reporting-date.yml
@@ -129,21 +129,21 @@ jobs:
             REPORTING_LOG=$(get_field "$item" "Reporting Log")
 
             # Parse tracked field values from the latest (first) entry in the log.
-            # Log format: ENTRY1|ENTRY2|... where each entry is DATE,STATUS,PRIORITY,ESTIMATE,REMAINING_WORK,TIME_SPENT
+            # Log format: ENTRY1 | ENTRY2 | ... where each entry is DATE, STATUS, PRIORITY, ESTIMATE, REMAINING_WORK, TIME_SPENT
             if [ -z "$REPORTING_LOG" ]; then
               LAST_STATUS="" LAST_PRIORITY="" LAST_ESTIMATE=""
               LAST_REMAINING_WORK="" LAST_TIME_SPENT=""
             else
-              LAST_ENTRY=$(echo "$REPORTING_LOG" | cut -d'|' -f1)
-              LAST_STATUS=$(echo         "$LAST_ENTRY" | cut -d',' -f2)
-              LAST_PRIORITY=$(echo       "$LAST_ENTRY" | cut -d',' -f3)
-              LAST_ESTIMATE=$(echo       "$LAST_ENTRY" | cut -d',' -f4)
-              LAST_REMAINING_WORK=$(echo "$LAST_ENTRY" | cut -d',' -f5)
-              LAST_TIME_SPENT=$(echo     "$LAST_ENTRY" | cut -d',' -f6)
+              LAST_ENTRY=$(echo "$REPORTING_LOG" | sed 's/ | /\n/g' | head -1)
+              LAST_STATUS=$(echo         "$LAST_ENTRY" | cut -d',' -f2 | xargs)
+              LAST_PRIORITY=$(echo       "$LAST_ENTRY" | cut -d',' -f3 | xargs)
+              LAST_ESTIMATE=$(echo       "$LAST_ENTRY" | cut -d',' -f4 | xargs)
+              LAST_REMAINING_WORK=$(echo "$LAST_ENTRY" | cut -d',' -f5 | xargs)
+              LAST_TIME_SPENT=$(echo     "$LAST_ENTRY" | cut -d',' -f6 | xargs)
             fi
 
-            echo "  Current : $STATUS,$PRIORITY,$ESTIMATE,$REMAINING_WORK,$TIME_SPENT"
-            echo "  Last log: $LAST_STATUS,$LAST_PRIORITY,$LAST_ESTIMATE,$LAST_REMAINING_WORK,$LAST_TIME_SPENT"
+            echo "  Current : $STATUS, $PRIORITY, $ESTIMATE, $REMAINING_WORK, $TIME_SPENT"
+            echo "  Last log: $LAST_STATUS, $LAST_PRIORITY, $LAST_ESTIMATE, $LAST_REMAINING_WORK, $LAST_TIME_SPENT"
 
             # Skip if nothing has changed
             if [ "$STATUS"         = "$LAST_STATUS"         ] && \
@@ -158,15 +158,15 @@ jobs:
 
             echo "  → Change detected. Updating 'Reporting Date' and prepending to 'Reporting Log'."
 
-            # Build new entry: DATE,STATUS,PRIORITY,ESTIMATE,REMAINING_WORK,TIME_SPENT
-            NEW_ENTRY="${TODAY},${STATUS},${PRIORITY},${ESTIMATE},${REMAINING_WORK},${TIME_SPENT}"
+            # Build new entry: DATE, STATUS, PRIORITY, ESTIMATE, REMAINING_WORK, TIME_SPENT
+            NEW_ENTRY="${TODAY}, ${STATUS}, ${PRIORITY}, ${ESTIMATE}, ${REMAINING_WORK}, ${TIME_SPENT}"
 
             # Prepend new entry and keep at most 5 entries total (discard oldest)
             if [ -z "$REPORTING_LOG" ]; then
               NEW_LOG="$NEW_ENTRY"
             else
-              TRIMMED=$(echo "$REPORTING_LOG" | tr '|' '\n' | head -4 | tr '\n' '|' | sed 's/|$//')
-              NEW_LOG="${NEW_ENTRY}|${TRIMMED}"
+              TRIMMED=$(echo "$REPORTING_LOG" | sed 's/ | /\n/g' | head -4 | paste -sd'~' | sed 's/~/ | /g')
+              NEW_LOG="${NEW_ENTRY} | ${TRIMMED}"
             fi
 
             # Update 'Reporting Date' to today


### PR DESCRIPTION
## Summary

- Field values within each entry now use `', '` as separator
- Log entries now use `' | '` as separator
- Parsing updated to use `sed 's/ | /\n/g'` to split entries and `cut -d','` + `xargs` to extract values
- Updated project setup guide and testing guide

## New log format example
```
2026-03-03, In Progress, High, 8, 5, 3 | 2026-03-01, Backlog, High, 8, 8, 0
```

## Note
Any existing `Reporting Log` values written by previous workflow runs have an incorrect format and should be cleared manually so the workflow can repopulate them correctly.