### PR TITLE
feat: sync GH reporting changes to JIRA via External Reference field

### DIFF
--- a/.github/workflows/track-reporting-date-project-setup.md
+++ b/.github/workflows/track-reporting-date-project-setup.md
@@ -14,13 +14,14 @@ The workflow reads and writes specific fields on each project item. All field na
 
 Changes to any of these fields trigger an update to `Reporting Date` and a new entry in `Reporting Log`.
 
-| Field name       | Type          | Notes                                      |
-|------------------|---------------|--------------------------------------------|
-| `Status`         | Single select | e.g. Backlog, In Progress, Done            |
-| `Priority`       | Single select | e.g. Low, Medium, High                     |
-| `Estimate`       | Number        | Estimated effort or story points           |
-| `Remaining Work` | Number        | Remaining effort                           |
-| `Time Spent`     | Number        | Time already spent                         |
+| Field name         | Type          | Notes                                                                                     |
+|--------------------|---------------|-------------------------------------------------------------------------------------------|
+| `Status`           | Single select | e.g. Backlog, In Progress, Done                                                           |
+| `Priority`         | Single select | e.g. Low, Medium, High                                                                    |
+| `Estimate`         | Number        | Estimated effort or story points                                                          |
+| `Remaining Work`   | Number        | Remaining effort                                                                          |
+| `Time Spent`       | Number        | Time already spent                                                                        |
+| `External Reference` | Text        | Optional JIRA ticket ID (e.g. `SRVLOGIC-774`). When set, changes are synced to JIRA at `https://issues.redhat.com/browse/{ID}` |
 
 ### Workflow-managed fields (written by the workflow)
 

--- a/.github/workflows/track-reporting-date-testing.md
+++ b/.github/workflows/track-reporting-date-testing.md
@@ -6,6 +6,11 @@ Make sure the setup from the guide is complete:
 - `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
 - The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting Date`** (Date) and a **`Reporting Log`** (Text) field
 
+To also test JIRA sync:
+- `JIRA_USER` and `JIRA_API_TOKEN` secrets are set in the repository
+- The project has an **`External Reference`** (Text) field
+- At least one project item has a valid JIRA ticket ID in `External Reference` (e.g. `SRVLOGIC-774`)
+
 ---
 
 ## Testing steps
@@ -22,6 +27,12 @@ Make sure the setup from the guide is complete:
 5. **Verify the result** → go back to the project item and confirm:
    - `Reporting Date` is set to today
    - `Reporting Log` has a new entry prepended in the format `YYYY-MM-DD, Status, Priority, Estimate, Remaining Work, Time Spent`, separated from older entries by ` | `, with a maximum of 5 entries total
+
+6. **Verify JIRA sync (if configured)** → open the JIRA ticket referenced in `External Reference` and confirm:
+   - **Priority** matches the value set in the project item
+   - **Original Estimate** matches the `Estimate` value
+   - **Remaining Estimate** matches the `Remaining Work` value
+   - A new **worklog entry** has been added with the `Time Spent` value
 
 ---
 
@@ -45,3 +56,6 @@ Change a field that is **not** in the tracked list (e.g. title or assignee). Aft
 - **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive)
 - **`Reporting Log` field not found** → the field name in the project doesn't exactly match `Reporting Log` (case-sensitive), or the field hasn't been created yet
 - **Item not processed** → the item may not appear in the first 100 results; increase the `items(first: 100)` limit in the workflow if the project has more than 100 items
+- **JIRA update failed (HTTP 401)** → `JIRA_USER` or `JIRA_API_TOKEN` secret is missing or incorrect
+- **JIRA update failed (HTTP 404)** → the ticket ID in `External Reference` does not exist or is not accessible with the provided credentials
+- **JIRA update failed (HTTP 400)** → a field value is in an unexpected format (e.g. Priority name doesn't match a valid JIRA priority, or time values are not in JIRA format such as `2h`, `1d`)

--- a/.github/workflows/track-reporting-date.md
+++ b/.github/workflows/track-reporting-date.md
@@ -48,6 +48,27 @@ In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the followin
 
 ---
 
+### 4. (Optional) Configure JIRA sync
+
+If you want changes to be synced to JIRA tickets, add the `External Reference` field to the project (see the [GitHub Project Setup Guide](track-reporting-date-project-setup.md)) and store two additional secrets:
+
+| Secret name      | Value                                                                 |
+|------------------|-----------------------------------------------------------------------|
+| `JIRA_USER`      | Your JIRA username or email address                                   |
+| `JIRA_API_TOKEN` | A JIRA API token (generate one at `https://id.atlassian.com/manage-profile/security/api-tokens`) |
+
+To add each secret: **`secret-santa-application` → Settings → Secrets and variables → Actions → New repository secret**.
+
+When `External Reference` is set on a project item (e.g. `SRVLOGIC-774`), the workflow will:
+- Update **Priority** and **time tracking** (Estimate → original estimate, Remaining Work → remaining estimate) on the JIRA ticket at `https://issues.redhat.com/browse/SRVLOGIC-774`
+- Log **Time Spent** as a new worklog entry on the JIRA ticket
+
+> **Note:** Time Spent is added as a worklog on every detected change, not as an absolute value. JIRA calculates total time spent from the sum of all worklog entries.
+
+If `JIRA_USER` or `JIRA_API_TOKEN` are not set, the JIRA sync step is skipped silently.
+
+---
+
 Once all steps are done, the workflow will run automatically every day at 05:00 UTC and update `Reporting Date` and `Reporting Log` whenever a tracked field has changed since the last run.
 
 ---

--- a/.github/workflows/track-reporting-date.yml
+++ b/.github/workflows/track-reporting-date.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      JIRA_USER: ${{ secrets.JIRA_USER }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_BASE_URL: https://issues.redhat.com
       PROJECT_OWNER: dgutierr-org
       PROJECT_NUMBER: 1
     steps:
@@ -194,6 +197,55 @@ jobs:
               }
             ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
               -f fieldId="$REPORTING_LOG_FIELD_ID" -f text="$NEW_LOG"
+
+            # Sync to JIRA if an External Reference is set
+            EXTERNAL_REF=$(get_field "$item" "External Reference")
+            if [ -n "$EXTERNAL_REF" ]; then
+              echo "  → Syncing to JIRA ticket: $EXTERNAL_REF"
+              JIRA_ISSUE_URL="${JIRA_BASE_URL}/rest/api/2/issue/${EXTERNAL_REF}"
+
+              # Build update payload: priority + time tracking (estimate and remaining work)
+              JIRA_PAYLOAD=$(jq -n \
+                --arg priority       "$PRIORITY" \
+                --arg estimate       "$ESTIMATE" \
+                --arg remainingWork  "$REMAINING_WORK" \
+                '{
+                  fields: {
+                    priority:     {name: $priority},
+                    timetracking: {originalEstimate: $estimate, remainingEstimate: $remainingWork}
+                  }
+                }')
+
+              HTTP_STATUS=$(curl -s -o /tmp/jira_resp.json -w "%{http_code}" \
+                -u "${JIRA_USER}:${JIRA_API_TOKEN}" \
+                -X PUT \
+                -H "Content-Type: application/json" \
+                -d "$JIRA_PAYLOAD" \
+                "$JIRA_ISSUE_URL")
+
+              if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+                echo "  → JIRA $EXTERNAL_REF updated (HTTP $HTTP_STATUS)"
+              else
+                echo "  → Warning: JIRA update failed for $EXTERNAL_REF (HTTP $HTTP_STATUS)"
+                cat /tmp/jira_resp.json
+              fi
+
+              # Log Time Spent as a worklog entry if provided
+              if [ -n "$TIME_SPENT" ]; then
+                WL_STATUS=$(curl -s -o /tmp/jira_wl.json -w "%{http_code}" \
+                  -u "${JIRA_USER}:${JIRA_API_TOKEN}" \
+                  -X POST \
+                  -H "Content-Type: application/json" \
+                  -d "$(jq -n --arg ts "$TIME_SPENT" '{timeSpent: $ts}')" \
+                  "${JIRA_ISSUE_URL}/worklog")
+                if [ "$WL_STATUS" -ge 200 ] && [ "$WL_STATUS" -lt 300 ]; then
+                  echo "  → Time Spent ($TIME_SPENT) logged to JIRA worklog."
+                else
+                  echo "  → Warning: Failed to log Time Spent to JIRA (HTTP $WL_STATUS)"
+                  cat /tmp/jira_wl.json
+                fi
+              fi
+            fi
 
             echo "  → Done."
             UPDATED_COUNT=$((UPDATED_COUNT + 1))


### PR DESCRIPTION
Closes #16

## What this PR adds

### JIRA sync on reporting changes

When the `track-reporting-date` workflow detects a change in tracked fields and the project item has a value in the new **`External Reference`** field, it now also syncs the change to the corresponding JIRA ticket.

**How it works:**
- `External Reference` stores the JIRA ticket ID only (e.g. `SRVLOGIC-774`)
- The JIRA ticket URL is constructed as `https://issues.redhat.com/browse/SRVLOGIC-774`
- The workflow calls the JIRA REST API (`PUT /rest/api/2/issue/{key}`) to update:
  - **Priority** → JIRA `priority.name`
  - **Estimate** → JIRA `timetracking.originalEstimate`
  - **Remaining Work** → JIRA `timetracking.remainingEstimate`
- **Time Spent** is logged as a new worklog entry (`POST /rest/api/2/issue/{key}/worklog`)

> **Note:** Time Spent is additive in JIRA — each detected change appends a new worklog entry. JIRA calculates total time spent from the sum of all worklog entries.

If `External Reference` is empty, or `JIRA_USER`/`JIRA_API_TOKEN` secrets are not set, the JIRA sync is skipped silently — existing behaviour is unchanged.

### New secrets required (for JIRA sync)

| Secret | Purpose |
|--------|---------|
| `JIRA_USER` | JIRA username or email |
| `JIRA_API_TOKEN` | JIRA API token |

### New project field required (for JIRA sync)

| Field | Type | Notes |
|-------|------|-------|
| `External Reference` | Text | Optional JIRA ticket ID (e.g. `SRVLOGIC-774`) |

---

## Files changed

- **`track-reporting-date.yml`** — added `JIRA_USER`, `JIRA_API_TOKEN`, `JIRA_BASE_URL` env vars; added JIRA sync block after GH field updates
- **`track-reporting-date-project-setup.md`** — added `External Reference` field to the tracked fields table
- **`track-reporting-date.md`** — added optional step 4 documenting JIRA secrets and sync behaviour
- **`track-reporting-date-testing.md`** — added JIRA prerequisites, verification step, and JIRA-specific troubleshooting entries

---

## Why cron instead of GitHub project events?

GitHub Actions does **not** natively support triggering workflows from GitHub Projects (v2) field changes. The available event triggers only fire on classic Projects (v1) or on issue/PR metadata — not on custom fields like `Status`, `Priority`, `Estimate`, etc.

The only way to detect custom field changes is by polling via the **GitHub GraphQL API**, hence the daily cron schedule. On each run, the workflow compares current field values against the last `Reporting Log` entry and acts only when a change is found.