### PR TITLE
fix: use JIRA PAT Bearer token auth instead of basic auth

### DIFF
--- a/.github/workflows/track-reporting-date-testing.md
+++ b/.github/workflows/track-reporting-date-testing.md
@@ -7,7 +7,7 @@ Make sure the setup from the guide is complete:
 - The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting Date`** (Date) and a **`Reporting Log`** (Text) field
 
 To also test JIRA sync:
-- `JIRA_USER` and `JIRA_API_TOKEN` secrets are set in the repository
+- `JIRA_API_TOKEN` secret is set in the repository (JIRA Personal Access Token)
 - The project has an **`External Reference`** (Text) field
 - At least one project item has a valid JIRA ticket ID in `External Reference` (e.g. `SRVLOGIC-774`)
 
@@ -56,6 +56,6 @@ Change a field that is **not** in the tracked list (e.g. title or assignee). Aft
 - **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive)
 - **`Reporting Log` field not found** → the field name in the project doesn't exactly match `Reporting Log` (case-sensitive), or the field hasn't been created yet
 - **Item not processed** → the item may not appear in the first 100 results; increase the `items(first: 100)` limit in the workflow if the project has more than 100 items
-- **JIRA update failed (HTTP 401)** → `JIRA_USER` or `JIRA_API_TOKEN` secret is missing or incorrect
+- **JIRA update failed (HTTP 401)** → `JIRA_API_TOKEN` secret is missing, expired, or not a valid JIRA Personal Access Token (PAT); basic auth credentials will not work — a PAT is required
 - **JIRA update failed (HTTP 404)** → the ticket ID in `External Reference` does not exist or is not accessible with the provided credentials
 - **JIRA update failed (HTTP 400)** → a field value is in an unexpected format (e.g. Priority name doesn't match a valid JIRA priority, or time values are not in JIRA format such as `2h`, `1d`)

--- a/.github/workflows/track-reporting-date.md
+++ b/.github/workflows/track-reporting-date.md
@@ -54,10 +54,11 @@ If you want changes to be synced to JIRA tickets, add the `External Reference` f
 
 | Secret name      | Value                                                                 |
 |------------------|-----------------------------------------------------------------------|
-| `JIRA_USER`      | Your JIRA username or email address                                   |
-| `JIRA_API_TOKEN` | A JIRA API token (generate one at `https://id.atlassian.com/manage-profile/security/api-tokens`) |
+| `JIRA_API_TOKEN` | A JIRA Personal Access Token (PAT) — generate one in JIRA at **Profile → Personal Access Tokens → Create token** |
 
-To add each secret: **`secret-santa-application` → Settings → Secrets and variables → Actions → New repository secret**.
+To add the secret: **`secret-santa-application` → Settings → Secrets and variables → Actions → New repository secret**.
+
+> **Note:** `issues.redhat.com` runs JIRA Data Center, which uses PAT-based Bearer token authentication. Basic auth (username + password/API key) is not supported.
 
 When `External Reference` is set on a project item (e.g. `SRVLOGIC-774`), the workflow will:
 - Update **Priority** and **time tracking** (Estimate → original estimate, Remaining Work → remaining estimate) on the JIRA ticket at `https://issues.redhat.com/browse/SRVLOGIC-774`
@@ -65,7 +66,7 @@ When `External Reference` is set on a project item (e.g. `SRVLOGIC-774`), the wo
 
 > **Note:** Time Spent is added as a worklog on every detected change, not as an absolute value. JIRA calculates total time spent from the sum of all worklog entries.
 
-If `JIRA_USER` or `JIRA_API_TOKEN` are not set, the JIRA sync step is skipped silently.
+If `JIRA_API_TOKEN` is not set, the JIRA sync step is skipped silently.
 
 ---
 

--- a/.github/workflows/track-reporting-date.yml
+++ b/.github/workflows/track-reporting-date.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      JIRA_USER: ${{ secrets.JIRA_USER }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_BASE_URL: https://issues.redhat.com
       PROJECT_OWNER: dgutierr-org
@@ -217,7 +216,7 @@ jobs:
                 }')
 
               HTTP_STATUS=$(curl -s -o /tmp/jira_resp.json -w "%{http_code}" \
-                -u "${JIRA_USER}:${JIRA_API_TOKEN}" \
+                -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
                 -X PUT \
                 -H "Content-Type: application/json" \
                 -d "$JIRA_PAYLOAD" \
@@ -233,7 +232,7 @@ jobs:
               # Log Time Spent as a worklog entry if provided
               if [ -n "$TIME_SPENT" ]; then
                 WL_STATUS=$(curl -s -o /tmp/jira_wl.json -w "%{http_code}" \
-                  -u "${JIRA_USER}:${JIRA_API_TOKEN}" \
+                  -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
                   -X POST \
                   -H "Content-Type: application/json" \
                   -d "$(jq -n --arg ts "$TIME_SPENT" '{timeSpent: $ts}')" \


### PR DESCRIPTION
## Problem

The JIRA sync step was failing with HTTP 401:

```
→ Warning: JIRA update failed for QUARKUS-7338 (HTTP 401)
Basic Authentication Failure - Reason : AUTHENTICATED_FAILED
```

`issues.redhat.com` runs **JIRA Data Center 9.12.32**, which does not accept Basic Auth with username + API key. It requires **Personal Access Token (PAT)** authentication via a Bearer token header.

## Fix

- Replaced `-u "${JIRA_USER}:${JIRA_API_TOKEN}"` with `-H "Authorization: Bearer ${JIRA_API_TOKEN}"` in both curl calls (issue update and worklog)
- Removed the unused `JIRA_USER` env var from the workflow
- Updated `track-reporting-date.md` to document that `JIRA_API_TOKEN` must be a JIRA PAT (generated at **Profile → Personal Access Tokens → Create token**), not an Atlassian Cloud API key
- Updated `track-reporting-date-testing.md` prerequisites and troubleshooting entry accordingly