### PR TITLE
fix: override JIRA time spent instead of accumulating worklogs

### DIFF
--- a/.github/workflows/track-reporting-date.yml
+++ b/.github/workflows/track-reporting-date.yml
@@ -191,8 +191,29 @@ jobs:
                   cat /tmp/jira_resp.json
                 fi
 
-                # Log Time Spent as a worklog entry if provided
+                # Override Time Spent: delete all existing worklogs, then add one with the exact value.
+                # This ensures JIRA's total time spent matches the GH value rather than accumulating.
                 if [ -n "$JIRA_TIME_SPENT" ]; then
+                  # Fetch all existing worklog IDs
+                  WL_LIST=$(curl -s \
+                    -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                    "${JIRA_ISSUE_URL}/worklog")
+                  WORKLOG_IDS=$(echo "$WL_LIST" | jq -r '.worklogs[].id // empty')
+
+                  # Delete each existing worklog
+                  for WL_ID in $WORKLOG_IDS; do
+                    DEL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                      -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                      -X DELETE \
+                      "${JIRA_ISSUE_URL}/worklog/${WL_ID}")
+                    if [ "$DEL_STATUS" -ge 200 ] && [ "$DEL_STATUS" -lt 300 ]; then
+                      echo "  → Deleted existing worklog $WL_ID."
+                    else
+                      echo "  → Warning: Failed to delete worklog $WL_ID (HTTP $DEL_STATUS)."
+                    fi
+                  done
+
+                  # Add a single worklog with the exact Time Spent value
                   WL_STATUS=$(curl -s -o /tmp/jira_wl.json -w "%{http_code}" \
                     -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
                     -X POST \
@@ -200,9 +221,9 @@ jobs:
                     -d "$(jq -n --arg ts "$JIRA_TIME_SPENT" '{timeSpent: $ts}')" \
                     "${JIRA_ISSUE_URL}/worklog")
                   if [ "$WL_STATUS" -ge 200 ] && [ "$WL_STATUS" -lt 300 ]; then
-                    echo "  → Time Spent ($JIRA_TIME_SPENT) logged to JIRA worklog."
+                    echo "  → Time Spent set to $JIRA_TIME_SPENT in JIRA worklog."
                   else
-                    echo "  → Warning: Failed to log Time Spent to JIRA (HTTP $WL_STATUS)"
+                    echo "  → Warning: Failed to set Time Spent in JIRA (HTTP $WL_STATUS)"
                     cat /tmp/jira_wl.json
                   fi
                 fi


### PR DESCRIPTION
## Problem

The previous implementation added a new worklog entry on every detected change, causing JIRA's total time spent to grow indefinitely (e.g. 3 runs × 4h = 12h logged even if the actual value never changed beyond 4h).

## Fix

Time Spent is now treated as an absolute value override:

1. **Fetch** all existing worklog IDs from the JIRA ticket (`GET /worklog`)
2. **Delete** each existing worklog (`DELETE /worklog/{id}`)
3. **Add** a single new worklog with the exact converted value (`POST /worklog`)

This ensures JIRA's total time spent always matches the current GH `Time Spent` field value.