### PR TITLE
fix: try PUT on managed worklog first, fall back to delta POST if editing fails

### DIFF
--- a/.github/workflows/track-reporting-date.yml
+++ b/.github/workflows/track-reporting-date.yml
@@ -191,51 +191,88 @@ jobs:
                   cat /tmp/jira_resp.json
                 fi
 
-                # Sync Time Spent: compare GH value with JIRA total timespent and log only the delta.
+                # Sync Time Spent:
+                # 1. Try to find and PUT-update the workflow-managed worklog in place.
+                # 2. If editing is not permitted, fall back to the delta approach:
+                #    GET JIRA issue timespent, compute GH - JIRA, POST a new worklog for the difference.
                 # GH stores time in weeks (1w = 5d = 40h); JIRA stores timespent in seconds.
-                # Only POST a worklog when GH > JIRA so values converge without needing delete permission.
                 if [ -n "$JIRA_TIME_SPENT" ]; then
-                  JIRA_GET_STATUS=$(curl -s -o /tmp/jira_issue.json -w "%{http_code}" \
+                  MANAGED_WL_COMMENT="[managed by track-reporting-date workflow]"
+                  TIME_SPENT_SYNCED=false
+
+                  # Step 1: look for the managed worklog and try to update it in place
+                  WL_LIST_STATUS=$(curl -s -o /tmp/jira_wl_list.json -w "%{http_code}" \
                     -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
-                    "${JIRA_ISSUE_URL}")
-                  echo "  → GET JIRA issue HTTP $JIRA_GET_STATUS"
+                    "${JIRA_ISSUE_URL}/worklog")
+                  echo "  → GET worklogs HTTP $WL_LIST_STATUS"
 
-                  if [ "$JIRA_GET_STATUS" -ge 200 ] && [ "$JIRA_GET_STATUS" -lt 300 ]; then
-                    JIRA_TIMESPENT_SECS=$(jq -r '.fields.timespent // 0' /tmp/jira_issue.json)
-                    echo "  → JIRA timespent: ${JIRA_TIMESPENT_SECS}s, GH Time Spent: ${TIME_SPENT}w"
+                  if [ "$WL_LIST_STATUS" -ge 200 ] && [ "$WL_LIST_STATUS" -lt 300 ]; then
+                    MANAGED_WL_ID=$(jq -r --arg c "$MANAGED_WL_COMMENT" \
+                      '.worklogs[] | select(.comment == $c) | .id' \
+                      /tmp/jira_wl_list.json | head -1)
 
-                    # Compute delta in hours using integer arithmetic (×1000 to avoid float issues).
-                    # GH weeks × 40000 = GH hours × 1000.
-                    # JIRA seconds × 1000 / 3600 = JIRA hours × 1000.
-                    # Output: "Xh" if GH > JIRA, empty if delta ≤ 0.
-                    DELTA_JIRA=$(awk -v gh="$TIME_SPENT" -v jira_s="$JIRA_TIMESPENT_SECS" 'BEGIN {
-                      gh_h1000   = int(gh * 40000 + 0.5)
-                      jira_h1000 = int(jira_s * 1000 / 3600 + 0.5)
-                      delta = gh_h1000 - jira_h1000
-                      if (delta > 0) printf "%dh\n", int(delta / 1000 + 0.5)
-                    }')
-
-                    if [ -n "$DELTA_JIRA" ]; then
-                      echo "  → Logging delta worklog: $DELTA_JIRA"
-                      WL_PAYLOAD=$(jq -n --arg ts "$DELTA_JIRA" '{timeSpent: $ts}')
+                    if [ -n "$MANAGED_WL_ID" ]; then
+                      WL_PAYLOAD=$(jq -n --arg ts "$JIRA_TIME_SPENT" --arg c "$MANAGED_WL_COMMENT" \
+                        '{timeSpent: $ts, comment: $c}')
                       WL_STATUS=$(curl -s -o /tmp/jira_wl.json -w "%{http_code}" \
                         -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
-                        -X POST \
+                        -X PUT \
                         -H "Content-Type: application/json" \
                         -d "$WL_PAYLOAD" \
-                        "${JIRA_ISSUE_URL}/worklog?adjustEstimate=leave")
+                        "${JIRA_ISSUE_URL}/worklog/${MANAGED_WL_ID}?adjustEstimate=leave")
                       if [ "$WL_STATUS" -ge 200 ] && [ "$WL_STATUS" -lt 300 ]; then
-                        echo "  → Delta $DELTA_JIRA logged (HTTP $WL_STATUS). JIRA total now ~${JIRA_TIME_SPENT}."
+                        echo "  → Time Spent updated to $JIRA_TIME_SPENT on managed worklog $MANAGED_WL_ID (HTTP $WL_STATUS)."
+                        TIME_SPENT_SYNCED=true
                       else
-                        echo "  → Warning: Failed to log Time Spent delta (HTTP $WL_STATUS)"
-                        cat /tmp/jira_wl.json
+                        echo "  → Cannot edit managed worklog $MANAGED_WL_ID (HTTP $WL_STATUS). Falling back to delta sync."
+                      fi
+                    fi
+                  fi
+
+                  # Step 2 (fallback): GET issue timespent, compute delta, POST new worklog for the difference
+                  if [ "$TIME_SPENT_SYNCED" = "false" ]; then
+                    JIRA_GET_STATUS=$(curl -s -o /tmp/jira_issue.json -w "%{http_code}" \
+                      -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                      "${JIRA_ISSUE_URL}")
+                    echo "  → GET JIRA issue HTTP $JIRA_GET_STATUS"
+
+                    if [ "$JIRA_GET_STATUS" -ge 200 ] && [ "$JIRA_GET_STATUS" -lt 300 ]; then
+                      JIRA_TIMESPENT_SECS=$(jq -r '.fields.timespent // 0' /tmp/jira_issue.json)
+                      echo "  → JIRA timespent: ${JIRA_TIMESPENT_SECS}s, GH Time Spent: ${TIME_SPENT}w"
+
+                      # Compute delta in hours using integer arithmetic (×1000 to avoid float issues).
+                      # GH weeks × 40000 = GH hours × 1000.
+                      # JIRA seconds × 1000 / 3600 = JIRA hours × 1000.
+                      # Output: "Xh" if GH > JIRA, empty if delta ≤ 0.
+                      DELTA_JIRA=$(awk -v gh="$TIME_SPENT" -v jira_s="$JIRA_TIMESPENT_SECS" 'BEGIN {
+                        gh_h1000   = int(gh * 40000 + 0.5)
+                        jira_h1000 = int(jira_s * 1000 / 3600 + 0.5)
+                        delta = gh_h1000 - jira_h1000
+                        if (delta > 0) printf "%dh\n", int(delta / 1000 + 0.5)
+                      }')
+
+                      if [ -n "$DELTA_JIRA" ]; then
+                        echo "  → Logging delta worklog: $DELTA_JIRA"
+                        WL_PAYLOAD=$(jq -n --arg ts "$DELTA_JIRA" '{timeSpent: $ts}')
+                        WL_STATUS=$(curl -s -o /tmp/jira_wl.json -w "%{http_code}" \
+                          -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                          -X POST \
+                          -H "Content-Type: application/json" \
+                          -d "$WL_PAYLOAD" \
+                          "${JIRA_ISSUE_URL}/worklog?adjustEstimate=leave")
+                        if [ "$WL_STATUS" -ge 200 ] && [ "$WL_STATUS" -lt 300 ]; then
+                          echo "  → Delta $DELTA_JIRA logged (HTTP $WL_STATUS). JIRA total now ~${JIRA_TIME_SPENT}."
+                        else
+                          echo "  → Warning: Failed to log Time Spent delta (HTTP $WL_STATUS)"
+                          cat /tmp/jira_wl.json
+                        fi
+                      else
+                        echo "  → Time Spent already up to date in JIRA (delta ≤ 0). Skipping."
                       fi
                     else
-                      echo "  → Time Spent already up to date in JIRA (delta ≤ 0). Skipping."
+                      echo "  → Warning: Failed to fetch JIRA issue $EXTERNAL_REF (HTTP $JIRA_GET_STATUS). Skipping Time Spent sync."
+                      cat /tmp/jira_issue.json
                     fi
-                  else
-                    echo "  → Warning: Failed to fetch JIRA issue $EXTERNAL_REF (HTTP $JIRA_GET_STATUS). Skipping Time Spent sync."
-                    cat /tmp/jira_issue.json
                   fi
                 fi
               fi


### PR DESCRIPTION
## Summary

Combines both worklog strategies into a two-step sync:

1. **Step 1 — try in-place update**: GET worklogs, find the comment-marked managed entry (`[managed by track-reporting-date workflow]`), attempt `PUT` to set `timeSpent` directly
2. **Step 2 — delta fallback**: if the PUT is not permitted (HTTP 400) or no managed worklog exists, GET the JIRA issue to read current `timespent` (seconds), compute `GH_hours - JIRA_hours`, and POST a new worklog for the difference only

Either path keeps GH and JIRA Time Spent in sync without requiring delete permission.

## Test plan

- [ ] Trigger workflow — if managed worklog edit succeeds: log shows `Time Spent updated to Xw on managed worklog <id>`
- [ ] Trigger workflow — if edit fails (HTTP 400): log shows `Cannot edit managed worklog ... Falling back to delta sync`, then `GET JIRA issue HTTP 200`, then delta is logged or skipped
- [ ] Run twice with same GH value: second run shows `delta ≤ 0. Skipping.`
- [ ] Increase GH Time Spent: next run logs exactly the difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)