### PR TITLE
docs: update guides for multi-project support and GitHub Actions Variables

### DIFF
--- a/.github/workflows/track-reporting-date-project-setup.md
+++ b/.github/workflows/track-reporting-date-project-setup.md
@@ -1,8 +1,14 @@
 # GitHub Project Setup Guide
 
-## Project
+## Projects
 
-**URL:** `https://github.com/orgs/dgutierr-org/projects/1`
+The workflow processes all projects listed in the `PROJECTS` repository variable. Each entry is an `owner:project_number` pair, e.g.:
+
+```
+dgutierr-org:1 another-org:3
+```
+
+Repeat the steps below for **every project** you add to the list.
 
 ---
 
@@ -14,14 +20,14 @@ The workflow reads and writes specific fields on each project item. All field na
 
 Changes to any of these fields trigger an update to `Reporting Date` and a new entry in `Reporting Log`.
 
-| Field name         | Type          | Notes                                                                                     |
-|--------------------|---------------|-------------------------------------------------------------------------------------------|
-| `Status`           | Single select | e.g. Backlog, In Progress, Done                                                           |
-| `Priority`         | Single select | e.g. Low, Medium, High                                                                    |
-| `Estimate`         | Number        | Estimated effort or story points                                                          |
-| `Remaining Work`   | Number        | Remaining effort                                                                          |
-| `Time Spent`       | Number        | Time already spent                                                                        |
-| `External Reference` | Text        | Optional JIRA ticket ID (e.g. `SRVLOGIC-774`). When set, changes are synced to JIRA at `https://issues.redhat.com/browse/{ID}` |
+| Field name           | Type          | Notes                                                                                     |
+|----------------------|---------------|-------------------------------------------------------------------------------------------|
+| `Status`             | Single select | e.g. Backlog, In Progress, Done                                                           |
+| `Priority`           | Single select | e.g. Low, Medium, High                                                                    |
+| `Estimate`           | Number        | Estimated effort in weeks (e.g. `2` = 2 weeks, `0.4` = 2 days, `0.1` = 4 hours)         |
+| `Remaining Work`     | Number        | Remaining effort in weeks                                                                 |
+| `Time Spent`         | Number        | Time already spent in weeks                                                               |
+| `External Reference` | Text          | Optional: ticket ID in the configured JIRA instance (e.g. `SRVLOGIC-774`). When set, changes are synced to JIRA at `<JIRA_BASE_URL>/browse/<ID>` |
 
 ### Workflow-managed fields (written by the workflow)
 
@@ -49,12 +55,13 @@ The oldest entry is automatically discarded when the log exceeds 5 entries.
 
 ---
 
-## How to add a field to the project
+## How to add a field to a project
 
-1. Go to **`https://github.com/orgs/dgutierr-org/projects/1`**
+1. Go to **`https://github.com/orgs/<org>/projects/<number>`**
 2. Click **"+"** at the right end of the column headers → **"New field"**
-3. Enter the field name and select the correct type
-4. Click **"Save"**
+3. Enter the field name exactly as shown in the table above (case-sensitive)
+4. Select the correct type
+5. Click **"Save"**
 
 ---
 

--- a/.github/workflows/track-reporting-date-testing.md
+++ b/.github/workflows/track-reporting-date-testing.md
@@ -4,7 +4,9 @@
 
 Make sure the setup from the guide is complete:
 - `GH_TOKEN` secret is set in the repository (PAT with `project` and `read:org` scopes)
-- The project (`https://github.com/orgs/dgutierr-org/projects/1`) has both a **`Reporting Date`** (Date) and a **`Reporting Log`** (Text) field
+- `PROJECTS` variable is set (e.g. `dgutierr-org:1`) — **Settings → Secrets and variables → Actions → Variables**
+- `JIRA_BASE_URL` variable is set (e.g. `https://issues.redhat.com`) — same location
+- Each project in `PROJECTS` has both a **`Reporting Date`** (Date) and a **`Reporting Log`** (Text) field
 
 To also test JIRA sync:
 - `JIRA_API_TOKEN` secret is set in the repository (JIRA Personal Access Token)
@@ -15,14 +17,17 @@ To also test JIRA sync:
 
 ## Testing steps
 
-1. **Go to your project** → `https://github.com/orgs/dgutierr-org/projects/1`
+1. **Go to a project** listed in your `PROJECTS` variable
 
 2. **Pick any issue/item** in the project and change one of the tracked fields:
    - Status, Priority, Estimate, Remaining Work, or Time Spent
 
 3. **Wait until 05:00 UTC** for the scheduled workflow to trigger, or use the manual trigger below to run it immediately
 
-4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Track Reporting Date on Field Changes` and inspect the logs. You should see the item listed with a change detected and an update confirmation.
+4. **Check the workflow ran** → go to your repository → **Actions** tab → open the latest run of `Track Reporting Date on Field Changes` and inspect the logs. You should see:
+   - A `========` header per project with the org and project number
+   - The item listed with a change detected and an update confirmation
+   - A per-project summary and a grand total at the end
 
 5. **Verify the result** → go back to the project item and confirm:
    - `Reporting Date` is set to today
@@ -32,7 +37,7 @@ To also test JIRA sync:
    - **Priority** matches the value set in the project item
    - **Original Estimate** matches the `Estimate` value
    - **Remaining Estimate** matches the `Remaining Work` value
-   - A new **worklog entry** has been added with the `Time Spent` value
+   - A worklog entry has been added or updated with a comment like `Copied time spent from GH #<issue>` or `Increased time spent from GH #<issue>`
 
 ---
 
@@ -40,7 +45,7 @@ To also test JIRA sync:
 
 1. Go to **Actions → Track Reporting Date on Field Changes → Run workflow**
 2. Click **"Run workflow"**
-3. The workflow runs immediately against the latest project state
+3. The workflow runs immediately against all projects in `PROJECTS`
 
 ---
 
@@ -53,9 +58,13 @@ Change a field that is **not** in the tracked list (e.g. title or assignee). Aft
 ## Troubleshooting
 
 - **Workflow fails with auth error** → the `GH_TOKEN` secret is missing or the PAT doesn't have `project` and `read:org` scopes
-- **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive)
-- **`Reporting Log` field not found** → the field name in the project doesn't exactly match `Reporting Log` (case-sensitive), or the field hasn't been created yet
+- **No projects processed / empty run** → the `PROJECTS` variable is not set or is empty; go to **Settings → Secrets and variables → Actions → Variables** and verify it exists
+- **`PROJECTS` variable not found** → make sure it is defined as a **Variable** (not a secret) in the repository or organization settings
+- **`JIRA_BASE_URL` variable not found** → same as above; JIRA sync will produce empty URLs if not set
+- **`Reporting Date` field not found** → the field name in the project doesn't exactly match `Reporting Date` (case-sensitive); the project is skipped and processing continues with the next one
+- **`Reporting Log` field not found** → the field name in the project doesn't exactly match `Reporting Log` (case-sensitive), or the field hasn't been created yet; same skip behaviour
 - **Item not processed** → the workflow paginates automatically (100 items per page); check the Actions log to see how many pages were fetched and confirm the item's page was processed
+- **Project in a different org not processed** → the PAT owner must be a member of that org, and for orgs with SAML SSO the PAT must be authorized for that org via **GitHub → Settings → Personal access tokens → Configure SSO → Authorize**
 - **JIRA update failed (HTTP 401)** → `JIRA_API_TOKEN` secret is missing, expired, or not a valid JIRA Personal Access Token (PAT); basic auth credentials will not work — a PAT is required
 - **JIRA update failed (HTTP 404)** → the ticket ID in `External Reference` does not exist or is not accessible with the provided credentials
 - **JIRA update failed (HTTP 400)** → a field value is in an unexpected format (e.g. Priority name doesn't match a valid JIRA priority, or time values are not in JIRA format such as `2h`, `1d`)

--- a/.github/workflows/track-reporting-date.md
+++ b/.github/workflows/track-reporting-date.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-Runs **daily at 05:00 UTC** and checks **all** project items. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
+Runs **daily at 05:00 UTC** and checks **all items across all configured projects**. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
 
 1. Sets **`Reporting Date`** to today
 2. Prepends a new entry to **`Reporting Log`** in the format:
@@ -16,14 +16,16 @@ No action is taken when non-tracked fields change (e.g. title, assignee).
 
 ## Setup
 
-### 1. Add the required fields to the project
+### 1. Add the required fields to each project
 
-In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the following fields exist:
+In every GitHub Project you want to track, make sure the following fields exist:
 
 | Field name       | Type   | Purpose                                                        |
 |------------------|--------|----------------------------------------------------------------|
 | `Reporting Date` | Date   | Set to today when a tracked field changes                      |
 | `Reporting Log`  | Text   | Log of tracked field values, newest entry first, max 5 entries |
+
+See the [GitHub Project Setup Guide](track-reporting-date-project-setup.md) for detailed instructions.
 
 ### 2. Create a Personal Access Token (PAT)
 
@@ -37,7 +39,9 @@ In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the followin
 
 > Why not use the default `GITHUB_TOKEN`? That token is automatically created per workflow run and is scoped to the repository only. It cannot read or write fields on organization-level GitHub Projects v2.
 
-### 3. Store the token as a repository secret
+The same PAT can access projects in multiple organizations as long as the token owner is a member of each org. For organizations with **SAML SSO**, the PAT must also be authorized for each org via **GitHub → Settings → Personal access tokens → Configure SSO → Authorize**.
+
+### 3. Store the PAT as a repository secret
 
 1. Go to your repository: **`secret-santa-application` → Settings → Secrets and variables → Actions**
 2. Click **"New repository secret"**
@@ -46,11 +50,32 @@ In **`https://github.com/orgs/dgutierr-org/projects/1`**, make sure the followin
    - **Secret**: paste the token you copied above
 4. Click **"Add secret"**
 
+### 4. Configure repository variables
+
+The workflow reads its project list and JIRA host from **GitHub Actions Variables** (plaintext config, not secrets).
+
+1. Go to **`secret-santa-application` → Settings → Secrets and variables → Actions → Variables tab**
+2. Click **"New repository variable"** and add the following:
+
+| Variable name  | Type     | Example value                          | Description |
+|----------------|----------|----------------------------------------|-------------|
+| `PROJECTS`     | Variable | `dgutierr-org:1 another-org:3`         | Space-separated list of `owner:project_number` pairs to process |
+| `JIRA_BASE_URL`| Variable | `https://issues.redhat.com`            | Base URL of the JIRA instance (no trailing slash) |
+
+**`PROJECTS` format:** each entry is `<org-login>:<project-number>`, separated by spaces. The project number is the integer shown in the project URL: `https://github.com/orgs/<org>/projects/<number>`.
+
+Example with three projects across two organizations:
+```
+dgutierr-org:1 dgutierr-org:2 another-org:5
+```
+
+> **Tip:** Variables can also be defined at the **organization level** (org Settings → Secrets and variables → Actions → Variables) and shared across multiple repositories, which is useful if several repos run this same workflow against the same set of projects.
+
 ---
 
-### 4. (Optional) Configure JIRA sync
+### 5. (Optional) Configure JIRA sync
 
-If you want changes to be synced to JIRA tickets, add the `External Reference` field to the project (see the [GitHub Project Setup Guide](track-reporting-date-project-setup.md)) and store two additional secrets:
+If you want changes to be synced to JIRA tickets, add the `External Reference` field to each project (see the [GitHub Project Setup Guide](track-reporting-date-project-setup.md)) and store one additional secret:
 
 | Secret name      | Value                                                                 |
 |------------------|-----------------------------------------------------------------------|
@@ -58,19 +83,19 @@ If you want changes to be synced to JIRA tickets, add the `External Reference` f
 
 To add the secret: **`secret-santa-application` → Settings → Secrets and variables → Actions → New repository secret**.
 
-> **Note:** `issues.redhat.com` runs JIRA Data Center, which uses PAT-based Bearer token authentication. Basic auth (username + password/API key) is not supported.
+> **Note:** JIRA Data Center (e.g. `issues.redhat.com`) uses PAT-based Bearer token authentication. Basic auth (username + password/API key) is not supported.
 
 When `External Reference` is set on a project item (e.g. `SRVLOGIC-774`), the workflow will:
-- Update **Priority** and **time tracking** (Estimate → original estimate, Remaining Work → remaining estimate) on the JIRA ticket at `https://issues.redhat.com/browse/SRVLOGIC-774`
-- Log **Time Spent** as a new worklog entry on the JIRA ticket
+- Update **Priority** and **time tracking** (Estimate → original estimate, Remaining Work → remaining estimate) on the JIRA ticket
+- Keep **Time Spent** in sync by logging a worklog entry whose comment identifies it as workflow-managed (e.g. `Copied time spent from GH #42` or `Increased time spent from GH #42`)
 
-> **Note:** Time Spent is added as a worklog on every detected change, not as an absolute value. JIRA calculates total time spent from the sum of all worklog entries.
+The JIRA ticket URL is constructed as `<JIRA_BASE_URL>/browse/<External Reference>`.
 
 If `JIRA_API_TOKEN` is not set, the JIRA sync step is skipped silently.
 
 ---
 
-Once all steps are done, the workflow will run automatically every day at 05:00 UTC and update `Reporting Date` and `Reporting Log` whenever a tracked field has changed since the last run.
+Once all steps are done, the workflow will run automatically every day at 05:00 UTC and update `Reporting Date` and `Reporting Log` whenever a tracked field has changed since the last run, across all projects listed in `PROJECTS`.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all three workflow guides to reflect the multi-project changes from PR #27.

### track-reporting-date.md (Setup Guide)
- Step 1 now says "each project" instead of linking a hardcoded URL
- New **Step 4 — Configure repository variables** explains `PROJECTS` and `JIRA_BASE_URL` variables with format, examples, and a tip about org-level variables
- Notes SAML SSO PAT authorization for cross-org access
- JIRA sync section removes hardcoded URL, references `JIRA_BASE_URL`
- Updates worklog description to mention comment format (`Copied/Increased time spent from GH #N`)

### track-reporting-date-project-setup.md
- Removes hardcoded `dgutierr-org:1` URL; explains the `PROJECTS` variable format
- Adds weeks-unit clarification to `Estimate`, `Remaining Work`, `Time Spent` fields
- Makes "How to add a field" generic (uses `<org>/<number>` placeholder)

### track-reporting-date-testing.md
- Prerequisites updated: `PROJECTS` and `JIRA_BASE_URL` variables listed alongside secrets
- Step 4 describes the new log structure (per-project `========` header + grand total)
- Step 6 updated to match new worklog comment format
- New troubleshooting entries: missing `PROJECTS`/`JIRA_BASE_URL` variables, cross-org PAT authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)