### PR TITLE
docs: generalize guide and update schedule to twice daily

### DIFF
--- a/.github/workflows/track-reporting-date.md
+++ b/.github/workflows/track-reporting-date.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-Runs **daily at 05:00 UTC** and checks **all items across all configured projects**. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
+Runs **twice daily at 00:00 and 12:00 UTC** and checks **all items across all configured projects**. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
 
 1. Sets **`Reporting Date`** to today
 2. Prepends a new entry to **`Reporting Log`** in the format:
@@ -30,7 +30,7 @@ In every GitHub Project you want to track, make sure the following fields exist 
 | `Estimate`           | Number        | Estimated effort in weeks (e.g. `2` = 2 weeks, `0.4` = 2 days, `0.1` = 4 hours)         |
 | `Remaining Work`     | Number        | Remaining effort in weeks                                                                 |
 | `Time Spent`         | Number        | Time already spent in weeks                                                               |
-| `External Reference` | Text          | Optional: JIRA ticket ID (e.g. `SRVLOGIC-774`). When set, changes are synced to JIRA.    |
+| `External Reference` | Text          | Optional: JIRA ticket ID (e.g. `ISSUE-774`). When set, changes are synced to JIRA.    |
 
 **Workflow-managed fields** — updated automatically, do not edit manually:
 
@@ -50,17 +50,11 @@ Example (newest → oldest, max 5 entries):
 2026-03-03, In Progress, High, 8, 5, 3 | 2026-03-01, Backlog, High, 8, 8, 0
 ```
 
-**How to add a field:**
-1. Go to `https://github.com/orgs/<org>/projects/<number>`
-2. Click **"+"** at the right end of the column headers → **"New field"**
-3. Enter the field name exactly as shown above and select the correct type
-4. Click **"Save"**
-
 ### 2. Create a Personal Access Token (PAT)
 
 1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
 2. Click **"Generate new token (classic)"**
-3. Give it a name (e.g. `secret-santa-project-automation`)
+3. Give it a name (e.g. `pm-automation`)
 4. Under **Scopes**, check both:
    - **`project`** — grants read/write access to GitHub Projects v2
    - **`read:org`** — required to access organization-level project data
@@ -72,7 +66,7 @@ The same PAT can access projects across multiple organizations as long as the to
 
 ### 3. Store the PAT as a repository secret
 
-1. Go to **`secret-santa-application` → Settings → Secrets and variables → Actions**
+1. Go to **`Repository` → Settings → Secrets and variables → Actions**
 2. Click **"New repository secret"**
 3. Set **Name** to `GH_TOKEN` and paste the token as the **Secret**
 4. Click **"Add secret"**
@@ -81,19 +75,19 @@ The same PAT can access projects across multiple organizations as long as the to
 
 The workflow reads its project list and JIRA host from **GitHub Actions Variables** (plaintext config, not secrets).
 
-1. Go to **`secret-santa-application` → Settings → Secrets and variables → Actions → Variables tab**
+1. Go to **`Repository` → Settings → Secrets and variables → Actions → Variables tab**
 2. Click **"New repository variable"** and add each of the following:
 
 | Variable name   | Example value               | Description |
 |-----------------|-----------------------------|-------------|
-| `PROJECTS`      | `dgutierr-org:1 another-org:3` | Space-separated `owner:project_number` pairs |
-| `JIRA_BASE_URL` | `https://issues.redhat.com` | Base URL of the JIRA instance (no trailing slash) |
+| `PROJECTS`      | `orgA:1 orgB:3` | Space-separated `owner:project_number` pairs |
+| `JIRA_BASE_URL` | `https://issues.org.com` | Base URL of the JIRA instance (no trailing slash) |
 
-**`PROJECTS` format:** each entry is `<org-login>:<project-number>`, separated by spaces. The project number is the integer in the project URL: `https://github.com/orgs/<org>/projects/<number>`.
+**`PROJECTS` format:** each entry is `<org>:<project-number>`, separated by spaces. The project number is the integer in the project URL: `https://github.com/orgs/<org>/projects/<number>`.
 
 Example with three projects across two organizations:
 ```
-dgutierr-org:1 dgutierr-org:2 another-org:5
+orgA:1 orgA:2 orgB:5
 ```
 
 > **Tip:** Variables can also be defined at the **organization level** (org Settings → Secrets and variables → Actions → Variables) and shared across multiple repositories.
@@ -103,12 +97,12 @@ dgutierr-org:1 dgutierr-org:2 another-org:5
 If you want changes to be synced to JIRA tickets, ensure the `External Reference` field is added to each project (step 1), then store one additional secret:
 
 1. Generate a JIRA Personal Access Token in JIRA at **Profile → Personal Access Tokens → Create token**
-2. Go to **`secret-santa-application` → Settings → Secrets and variables → Actions → New repository secret**
+2. Go to **`Repository` → Settings → Secrets and variables → Actions → New repository secret**
 3. Set **Name** to `JIRA_API_TOKEN` and paste the token as the **Secret**
 
-> **Note:** JIRA Data Center (e.g. `issues.redhat.com`) uses PAT-based Bearer token authentication. Basic auth (username + password/API key) is not supported.
+> **Note:** JIRA Data Center (e.g. `issues.org.com`) uses PAT-based Bearer token authentication. Basic auth (username + password/API key) is not supported.
 
-When `External Reference` is set on a project item (e.g. `SRVLOGIC-774`), the workflow will:
+When `External Reference` is set on a project item (e.g. `ISSUE-774`), the workflow will:
 - Update **Priority** and **time tracking** (Estimate → original estimate, Remaining Work → remaining estimate) on the JIRA ticket at `<JIRA_BASE_URL>/browse/<External Reference>`
 - Keep **Time Spent** in sync: first sync logs a `Copied time spent from GH #<issue>` worklog; subsequent increases log an `Increased time spent from GH #<issue>` worklog
 
@@ -116,7 +110,7 @@ If `JIRA_API_TOKEN` is not set, the JIRA sync step is skipped silently.
 
 ---
 
-Once all steps are done, the workflow runs automatically every day at 05:00 UTC across all projects listed in `PROJECTS`.
+Once all steps are done, the workflow runs automatically twice daily (00:00 and 12:00 UTC) across all projects listed in `PROJECTS`.
 
 ---
 
@@ -125,8 +119,8 @@ Once all steps are done, the workflow runs automatically every day at 05:00 UTC 
 ### Prerequisites
 
 - `GH_TOKEN` secret is set (PAT with `project` and `read:org` scopes)
-- `PROJECTS` variable is set (e.g. `dgutierr-org:1`) — **Settings → Secrets and variables → Actions → Variables**
-- `JIRA_BASE_URL` variable is set (e.g. `https://issues.redhat.com`) — same location
+- `PROJECTS` variable is set (e.g. `orgA:1`) — **Settings → Secrets and variables → Actions → Variables**
+- `JIRA_BASE_URL` variable is set (e.g. `https://issues.org.com`) — same location
 - Each project in `PROJECTS` has `Reporting Date` and `Reporting Log` fields
 
 For JIRA sync testing also:
@@ -187,12 +181,3 @@ The only way to react to custom project field changes in GitHub Actions is via t
 3. If anything changed since the last run, it updates `Reporting Date` and prepends a new entry to `Reporting Log`.
 
 This is a known limitation of GitHub Projects v2 — there is no `project_field_changed` webhook or Actions trigger available.
-
----
-
-## Cleanup
-
-If the `Reporting Hash` field was created during a previous version of this workflow, it is no longer needed and can be safely removed:
-
-1. Go to the project **Settings → Fields**
-2. Find `Reporting Hash` and delete it

--- a/.github/workflows/track-reporting-date.yml
+++ b/.github/workflows/track-reporting-date.yml
@@ -8,7 +8,7 @@ name: Track Reporting Date on Field Changes
 # ---------------------------------------------------------------------------
 on:
   schedule:
-    - cron: '0 5 * * *'   # daily at 05:00 UTC
+    - cron: '0 */12 * * *'   # twice daily at 00:00 and 12:00 UTC
   workflow_dispatch:
 
 # Requires a PAT with 'project' and 'read:org' scopes stored as secret GH_TOKEN.


### PR DESCRIPTION
## Summary

- Replace all specific references with generic placeholders (`orgA`/`orgB`, `Repository`, `pm-automation`, `https://issues.org.com`, `ISSUE-774`)
- Remove Cleanup section
- Remove "How to add a field" instructions
- Update workflow schedule from daily at 05:00 UTC to twice daily (`0 */12 * * *` — 00:00 and 12:00 UTC)
- Update all schedule references in the guide to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)