### PR TITLE
chore: rename workflow to 'Sync Project Reporting Metrics'

### DIFF
--- a/.github/workflows/sync-project-reporting-metrics.md
+++ b/.github/workflows/sync-project-reporting-metrics.md
@@ -1,4 +1,4 @@
-# Sync Project(s) Reporting Metrics
+# Sync Project Reporting Metrics
 
 ## What it does
 
@@ -129,7 +129,7 @@ For JIRA sync testing also:
 
 ### Manual trigger (skip the scheduled wait)
 
-1. Go to **Actions → Sync Project(s) Reporting Metrics → Run workflow**
+1. Go to **Actions → Sync Project Reporting Metrics → Run workflow**
 2. Click **"Run workflow"**
 3. The workflow runs immediately against all projects in `PROJECTS`
 
@@ -138,7 +138,7 @@ For JIRA sync testing also:
 1. **Go to a project** listed in your `PROJECTS` variable and pick any issue/item
 2. **Change one of the tracked fields**: Status, Priority, Estimate, Remaining Work, or Time Spent
 3. **Trigger the workflow** manually (see above) or wait for 05:00 UTC
-4. **Check the Actions log** → open the latest run of `Sync Project(s) Reporting Metrics`. You should see:
+4. **Check the Actions log** → open the latest run of `Sync Project Reporting Metrics`. You should see:
    - A `========` header per project with the org and project number
    - The item listed with a change detected and an update confirmation
    - A per-project summary and a grand total at the end

--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -1,4 +1,4 @@
-name: Sync Project(s) Reporting Metrics
+name: Sync Project Reporting Metrics
 
 # ---------------------------------------------------------------------------
 # Schedule configuration
@@ -16,7 +16,7 @@ on:
 
 jobs:
   track-reporting-date:
-    name: Sync project(s) reporting metrics
+    name: Sync project reporting metrics
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
       PROJECTS: ${{ vars.PROJECTS }}
     steps:
-      - name: Sync project(s) reporting metrics across all configured projects
+      - name: Sync project reporting metrics across all configured projects
         run: |
           set -e
 


### PR DESCRIPTION
## Summary
- Renames `track-reporting-date.yml` → `sync-project-reporting-metrics.yml`
- Renames `track-reporting-date.md` → `sync-project-reporting-metrics.md`
- Updates workflow `name:`, job name, and step name to `Sync Project Reporting Metrics`
- Updates `.md` description to emphasize this is an automation workflow for progress reporting and sync across multiple GitHub Projects

## Test plan
- [ ] Verify workflow appears under `Sync Project Reporting Metrics` in the Actions UI
- [ ] Verify `.md` guide reflects the updated name and description